### PR TITLE
[issue #10] Swagger Mock API 추가 Notification

### DIFF
--- a/src/main/java/yapp/buddycon/common/PagingDto.java
+++ b/src/main/java/yapp/buddycon/common/PagingDto.java
@@ -1,0 +1,16 @@
+package yapp.buddycon.common;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import lombok.Getter;
+
+@Getter
+public class PagingDto {
+
+  @Min(value = 0)
+  private int page = 0;
+  @Min(value = 1)
+  @Max(value = 1000)
+  private int rowCount = 20;
+
+}

--- a/src/main/java/yapp/buddycon/web/notification/adapter/in/NotificationController.java
+++ b/src/main/java/yapp/buddycon/web/notification/adapter/in/NotificationController.java
@@ -1,0 +1,36 @@
+package yapp.buddycon.web.notification.adapter.in;
+
+import io.swagger.v3.oas.annotations.Operation;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import yapp.buddycon.common.PagingDto;
+import yapp.buddycon.web.auth.adapter.out.AuthMember;
+import yapp.buddycon.web.notification.adapter.in.response.NotificationResponseDto;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1/notification")
+public class NotificationController {
+
+  @GetMapping("")
+  @Operation(summary = "알림 목록 조회", description = "알림 목록 조회 및 확인 완료 처리")
+  public Page<NotificationResponseDto> getNotifications(AuthMember authMember,
+      @Valid PagingDto dto) {
+    Page<NotificationResponseDto> page = null;
+    return page;
+  }
+
+  @GetMapping("/{notification-id}")
+  @Operation(summary = "알림 상세 조회")
+  public NotificationResponseDto getNotification(AuthMember authMember,
+      @PathVariable(value = "notification-id") Long notificationId) {
+    NotificationResponseDto result = null;
+    return result;
+  }
+
+}

--- a/src/main/java/yapp/buddycon/web/notification/adapter/in/response/NotificationResponseDto.java
+++ b/src/main/java/yapp/buddycon/web/notification/adapter/in/response/NotificationResponseDto.java
@@ -1,7 +1,6 @@
 package yapp.buddycon.web.notification.adapter.in.response;
 
 import java.time.LocalDate;
-import yapp.buddycon.web.coupon.domain.CouponState;
 import yapp.buddycon.web.coupon.domain.CouponType;
 
 public record NotificationResponseDto(
@@ -13,13 +12,8 @@ public record NotificationResponseDto(
 
     // coupon
     Long couponId,
-    CouponState couponState,
     CouponType couponType,
-    String couponImageUrl,
     String couponName,
-    String couponMemo,
-    String storeName,
-    String sentMemberName,
     LocalDate expireDate
 ) {
 

--- a/src/main/java/yapp/buddycon/web/notification/adapter/in/response/NotificationResponseDto.java
+++ b/src/main/java/yapp/buddycon/web/notification/adapter/in/response/NotificationResponseDto.java
@@ -1,0 +1,26 @@
+package yapp.buddycon.web.notification.adapter.in.response;
+
+import java.time.LocalDate;
+import yapp.buddycon.web.coupon.domain.CouponState;
+import yapp.buddycon.web.coupon.domain.CouponType;
+
+public record NotificationResponseDto(
+    // notification
+    Long id,
+    String title,
+    String body,
+    boolean checked,
+
+    // coupon
+    Long couponId,
+    CouponState couponState,
+    CouponType couponType,
+    String couponImageUrl,
+    String couponName,
+    String couponMemo,
+    String storeName,
+    String sentMemberName,
+    LocalDate expireDate
+) {
+
+}

--- a/src/main/java/yapp/buddycon/web/notification/adapter/out/NotificationJpaRepository.java
+++ b/src/main/java/yapp/buddycon/web/notification/adapter/out/NotificationJpaRepository.java
@@ -1,0 +1,8 @@
+package yapp.buddycon.web.notification.adapter.out;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import yapp.buddycon.web.notification.domain.Notification;
+
+public interface NotificationJpaRepository extends JpaRepository<Notification, Long> {
+
+}

--- a/src/main/java/yapp/buddycon/web/notification/domain/Notification.java
+++ b/src/main/java/yapp/buddycon/web/notification/domain/Notification.java
@@ -1,0 +1,34 @@
+package yapp.buddycon.web.notification.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import yapp.buddycon.common.domain.BaseEntity;
+import yapp.buddycon.web.coupon.domain.Coupon;
+import yapp.buddycon.web.member.domain.Member;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+public class Notification extends BaseEntity {
+
+  @Column(name = "title", length = 50)
+  private String title;
+
+  @Column(name = "body", columnDefinition = "TEXT")
+  private String body;
+
+  private boolean checked;
+
+  @ManyToOne
+  @JoinColumn(name = "member_id")
+  private Member member;
+
+  @ManyToOne
+  @JoinColumn(name = "coupon_id")
+  private Coupon coupon;
+
+}


### PR DESCRIPTION
## 개요

Notification 관련 목업 코드 추가

## 작업 내용

- Notification 엔티티 추가
- `/api/v1/notification` API 추가
- NotificationResponseDto 추가
- 범용으로 사용할 PagingDto 추가

## 메모

common에 PagingDto를 추가했습니다. 목록 조회 시 해당 클래스를 extend 해서 사용하면 좋을 듯 합니다.

close #10 
resolved #10 