### PR TITLE
[issue #12] Swagger Mock API 추가 - Member, NotificationSetting

### DIFF
--- a/src/main/java/yapp/buddycon/web/auth/adapter/in/LoginController.java
+++ b/src/main/java/yapp/buddycon/web/auth/adapter/in/LoginController.java
@@ -25,10 +25,4 @@ public class LoginController {
 //    return authService.reissue(reissueRequestDto);
 //  }
 
-  @PostMapping("unregister")
-  @Operation(summary = "회원 탈퇴")
-  public void unregister(AuthMember authMember) {
-
-  }
-
 }

--- a/src/main/java/yapp/buddycon/web/auth/adapter/in/LoginController.java
+++ b/src/main/java/yapp/buddycon/web/auth/adapter/in/LoginController.java
@@ -1,8 +1,10 @@
 package yapp.buddycon.web.auth.adapter.in;
 
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import yapp.buddycon.web.auth.adapter.in.response.TokenResponseDto;
+import yapp.buddycon.web.auth.adapter.out.AuthMember;
 import yapp.buddycon.web.auth.application.service.AuthService;
 
 @RestController
@@ -13,6 +15,7 @@ public class LoginController {
   private final AuthService authService;
 
   @PostMapping("login/{accessToken}")
+  @Operation(summary = "로그인", description = "최초 로그인일 경우 회원가입 처리")
   public TokenResponseDto login(@PathVariable String accessToken) {
     return authService.login(accessToken);
   }
@@ -21,5 +24,11 @@ public class LoginController {
 //  public TokenResponseDto reissue(@RequestBody ReissueRequestDto reissueRequestDto) {
 //    return authService.reissue(reissueRequestDto);
 //  }
+
+  @PostMapping("unregister")
+  @Operation(summary = "회원 탈퇴")
+  public void unregister(AuthMember authMember) {
+
+  }
 
 }

--- a/src/main/java/yapp/buddycon/web/member/adapter/in/MemberController.java
+++ b/src/main/java/yapp/buddycon/web/member/adapter/in/MemberController.java
@@ -1,0 +1,32 @@
+package yapp.buddycon.web.member.adapter.in;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import yapp.buddycon.web.auth.adapter.out.AuthMember;
+import yapp.buddycon.web.member.adapter.in.request.NotificationSettingUpdateRequestDto;
+import yapp.buddycon.web.member.adapter.in.response.NotificationSettingResponseDto;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1/member")
+public class MemberController {
+
+  @GetMapping("/notification-setting")
+  @Operation(summary = "유저 알림 설정 조회")
+  public NotificationSettingResponseDto getNotificationSetting(AuthMember authMember) {
+    NotificationSettingResponseDto dto = null;
+    return dto;
+  }
+
+  @PutMapping("/notification-setting")
+  @Operation(summary = "유저 알림 설정 수정")
+  public void updateNotificationSetting(AuthMember authMember,
+      NotificationSettingUpdateRequestDto dto) {
+
+  }
+
+}

--- a/src/main/java/yapp/buddycon/web/member/adapter/in/MemberController.java
+++ b/src/main/java/yapp/buddycon/web/member/adapter/in/MemberController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import yapp.buddycon.web.auth.adapter.out.AuthMember;
@@ -23,7 +23,7 @@ public class MemberController {
     return dto;
   }
 
-  @PutMapping("/notification-setting")
+  @PatchMapping("/notification-setting")
   @Operation(summary = "유저 알림 설정 수정")
   public void updateNotificationSetting(AuthMember authMember,
       NotificationSettingUpdateRequestDto dto) {

--- a/src/main/java/yapp/buddycon/web/member/adapter/in/MemberController.java
+++ b/src/main/java/yapp/buddycon/web/member/adapter/in/MemberController.java
@@ -2,6 +2,7 @@ package yapp.buddycon.web.member.adapter.in;
 
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,6 +27,12 @@ public class MemberController {
   @Operation(summary = "유저 알림 설정 수정")
   public void updateNotificationSetting(AuthMember authMember,
       NotificationSettingUpdateRequestDto dto) {
+
+  }
+
+  @DeleteMapping("/self")
+  @Operation(summary = "회원 탈퇴")
+  public void deleteMember(AuthMember authMember) {
 
   }
 

--- a/src/main/java/yapp/buddycon/web/member/adapter/in/request/NotificationSettingUpdateRequestDto.java
+++ b/src/main/java/yapp/buddycon/web/member/adapter/in/request/NotificationSettingUpdateRequestDto.java
@@ -1,0 +1,11 @@
+package yapp.buddycon.web.member.adapter.in.request;
+
+public record NotificationSettingUpdateRequestDto(
+    Boolean activate,
+    Boolean fourteenDaysLeft,
+    Boolean sevenDaysLeft,
+    Boolean threeDaysLeft,
+    Boolean oneDaysLeft
+) {
+
+}

--- a/src/main/java/yapp/buddycon/web/member/adapter/in/response/NotificationSettingResponseDto.java
+++ b/src/main/java/yapp/buddycon/web/member/adapter/in/response/NotificationSettingResponseDto.java
@@ -1,0 +1,12 @@
+package yapp.buddycon.web.member.adapter.in.response;
+
+public record NotificationSettingResponseDto(
+    Long id,
+    boolean activate,
+    boolean fourteenDaysLeft,
+    boolean sevenDaysLeft,
+    boolean threeDaysLeft,
+    boolean oneDaysLeft
+) {
+
+}

--- a/src/main/java/yapp/buddycon/web/member/adapter/in/response/NotificationSettingResponseDto.java
+++ b/src/main/java/yapp/buddycon/web/member/adapter/in/response/NotificationSettingResponseDto.java
@@ -1,7 +1,7 @@
 package yapp.buddycon.web.member.adapter.in.response;
 
 public record NotificationSettingResponseDto(
-    Long id,
+    long id,
     boolean activate,
     boolean fourteenDaysLeft,
     boolean sevenDaysLeft,

--- a/src/main/java/yapp/buddycon/web/member/domain/NotificationSetting.java
+++ b/src/main/java/yapp/buddycon/web/member/domain/NotificationSetting.java
@@ -1,0 +1,30 @@
+package yapp.buddycon.web.member.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import yapp.buddycon.common.domain.BaseEntity;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+public class NotificationSetting extends BaseEntity {
+
+  @OneToOne
+  @JoinColumn(name = "member_id")
+  private Member member;
+
+  private boolean activate;
+
+  private boolean fourteenDaysLeft;
+
+  private boolean sevenDaysLeft;
+
+  private boolean threeDaysLeft;
+
+  private boolean oneDaysLeft;
+
+  // default: sevenDaysLeft = TRUE
+}


### PR DESCRIPTION
## 개요

Member, NotificationSetting 관련 목업 코드 추가

## 작업 내용

- NotificationSetting 엔티티 추가
- `GET::/api/v1/member/notification-setting`, `PUT::/api/v1/member/notification-setting` API 추가
- NotificationSettingResponseDto, NotificationSettingUpdateRequestDto 추가

## 메모

notification 패키지와 member 패키지 사이에서 고민하다가 
회원가입 시 같이 생성되는 데이터라는 점과 로그인한 유저의 데이터를 가져온다는 점에서 member 안에 귀속되어 있는 정보라고 생각되어 member로 정했습니다!

close #12 
resolve #12 
