### PR TITLE
[Issue #9] Swagger Mock API 추가 - Coupon

### DIFF
--- a/src/main/java/yapp/buddycon/common/response/DefaultResponseDto.java
+++ b/src/main/java/yapp/buddycon/common/response/DefaultResponseDto.java
@@ -1,0 +1,7 @@
+package yapp.buddycon.common.response;
+
+public record DefaultResponseDto(
+  boolean success,
+  String message
+) {
+}

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/in/CouponController.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/in/CouponController.java
@@ -1,9 +1,19 @@
 package yapp.buddycon.web.coupon.adapter.in;
 
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import yapp.buddycon.common.response.DefaultResponseDto;
+import yapp.buddycon.web.auth.adapter.out.AuthMember;
+import yapp.buddycon.web.coupon.adapter.in.request.*;
+import yapp.buddycon.web.coupon.adapter.in.response.CouponsResponseDto;
+import yapp.buddycon.web.coupon.adapter.in.response.CustomCouponInfoResponseDto;
+import yapp.buddycon.web.coupon.adapter.in.response.GifticonInfoResponseDto;
 import yapp.buddycon.web.coupon.application.port.in.CouponUseCase;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -11,5 +21,71 @@ import yapp.buddycon.web.coupon.application.port.in.CouponUseCase;
 public class CouponController {
 
   private final CouponUseCase couponUseCase;
+
+  @GetMapping("gifticon")
+  @Operation(summary = "기프티콘 정렬 조회")
+  public List<CouponsResponseDto> getSortedGifticons(@RequestParam("usable") boolean usable, Pageable pageable, AuthMember authMember) {
+    return null;
+  }
+
+  @GetMapping("custom-coupon")
+  @Operation(summary = "제작티콘 정렬 조회")
+  public List<CouponsResponseDto> getSortedCustomCoupons(@RequestParam("usable") boolean usable, Pageable pageable, AuthMember authMember) {
+    return null;
+  }
+
+  @GetMapping("gifticon/{id}")
+  @Operation(summary = "기프티콘 상세 조회")
+  public GifticonInfoResponseDto getGifticonInfo(@PathVariable("id") long id) {
+    return null;
+  }
+
+  @GetMapping("custom-coupon/{id}")
+  @Operation(summary = "제작티콘 상세 조회")
+  public CustomCouponInfoResponseDto getCustomCouponInfo(@PathVariable("id") long id) {
+    return null;
+  }
+
+  @PatchMapping("{id}/state")
+  @Operation(summary = "쿠폰 상태 변경", description = "상태 : USED, USABLE")
+  public DefaultResponseDto changeCouponState(@PathVariable("id") long id, @RequestBody CouponStateRequestDto couponStateRequestDto) {
+    return null;
+  }
+
+  @PostMapping("gifticon")
+  @Operation(summary = "기프티콘 제작")
+  public DefaultResponseDto makeGifticon(@RequestPart GifticonCreationRequestDto gifticonCreationRequestDto, @RequestPart MultipartFile image, AuthMember authMember) {
+    return null;
+  }
+
+  @PostMapping("custom-coupon")
+  @Operation(summary = "제작티콘 제작")
+  public DefaultResponseDto makeCustomCoupon(@RequestPart CustomCouponCreationRequestDto customCouponCreationRequestDto, @RequestPart MultipartFile image, AuthMember authMember) {
+    return null;
+  }
+
+  @GetMapping("custom-coupon/{barcode}")
+  @Operation(summary = "바코드로 제작티콘 정보 불러오기")
+  public CustomCouponInfoResponseDto getCustomCouponInfoByBarcode(@PathVariable("barcode") String barcode, AuthMember authMember) {
+    return null;
+  }
+
+  @DeleteMapping("{id}")
+  @Operation(summary = "쿠폰 삭제")
+  public DefaultResponseDto deleteCoupon(@PathVariable("id") long id) {
+    return null;
+  }
+
+  @PutMapping("gifticon/{id}")
+  @Operation(summary = "기프티콘 정보 수정")
+  public DefaultResponseDto editGifticonInfo(@PathVariable("id") long id, @RequestBody GifticonInfoRequestDto gifticonInfoRequestDto) {
+    return null;
+  }
+
+  @PutMapping("custom-coupon/{id}")
+  @Operation(summary = "제작티콘 정보 수정")
+  public DefaultResponseDto editCustomCouponInfo(@PathVariable("id") long id, @RequestBody CustomCouponInfoRequestDto customCouponInfoRequestDto) {
+    return null;
+  }
 
 }

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/in/SharedCouponController.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/in/SharedCouponController.java
@@ -1,14 +1,39 @@
 package yapp.buddycon.web.coupon.adapter.in;
 
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
+import yapp.buddycon.common.response.DefaultResponseDto;
+import yapp.buddycon.web.auth.adapter.out.AuthMember;
+import yapp.buddycon.web.coupon.adapter.in.request.CouponStateRequestDto;
+import yapp.buddycon.web.coupon.adapter.in.response.SharedCouponsResponseDto;
 import yapp.buddycon.web.coupon.application.port.in.SharedCouponUseCase;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("api/v1/coupon/share")
+@RequestMapping("api/v1/coupon/share/")
 public class SharedCouponController {
 
   private final SharedCouponUseCase sharedCouponUseCase;
+
+  @GetMapping("")
+  @Operation(summary = "만든쿠폰 정렬 조회")
+  public List<SharedCouponsResponseDto> getSortedSharedCoupons(Pageable pageable) {
+    return null;
+  }
+
+  @PatchMapping("{id}/state")
+  @Operation(summary = "제작티콘 선물 후 공유완료 상태로 변경", description = "카카오톡으로 메시지를 보내기를 성공한 경우 api")
+  public DefaultResponseDto changeCustomCouponState(@PathVariable("id") long id) {
+    return null;
+  }
+
+  @DeleteMapping("{id}")
+  @Operation(summary = "만든쿠폰 삭제")
+  public DefaultResponseDto deleteSharedCoupon(@PathVariable("id") long id) {
+    return null;
+  }
 }

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/in/request/CouponStateRequestDto.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/in/request/CouponStateRequestDto.java
@@ -1,0 +1,8 @@
+package yapp.buddycon.web.coupon.adapter.in.request;
+
+import yapp.buddycon.web.coupon.domain.CouponState;
+
+public record CouponStateRequestDto(
+  String state
+) {
+}

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/in/request/CustomCouponCreationRequestDto.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/in/request/CustomCouponCreationRequestDto.java
@@ -1,0 +1,12 @@
+package yapp.buddycon.web.coupon.adapter.in.request;
+
+import java.time.LocalDate;
+
+public record CustomCouponCreationRequestDto(
+  String barcode,
+  String name,
+  LocalDate expireDate,
+  String storeName,
+  String memo
+) {
+}

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/in/request/CustomCouponInfoRequestDto.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/in/request/CustomCouponInfoRequestDto.java
@@ -1,0 +1,12 @@
+package yapp.buddycon.web.coupon.adapter.in.request;
+
+import java.time.LocalDate;
+
+public record CustomCouponInfoRequestDto(
+  String name,
+  LocalDate expireDate,
+  String storeName,
+  String sentMemberName,
+  String memo
+) {
+}

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/in/request/GifticonCreationRequestDto.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/in/request/GifticonCreationRequestDto.java
@@ -1,0 +1,14 @@
+package yapp.buddycon.web.coupon.adapter.in.request;
+
+import java.time.LocalDate;
+
+public record GifticonCreationRequestDto(
+  String barcode,
+  String name,
+  LocalDate expireDate,
+  String storeName,
+  String memo,
+  boolean isMoneyCoupon,
+  Integer leftMoney
+) {
+}

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/in/request/GifticonInfoRequestDto.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/in/request/GifticonInfoRequestDto.java
@@ -1,0 +1,13 @@
+package yapp.buddycon.web.coupon.adapter.in.request;
+
+import java.time.LocalDate;
+
+public record GifticonInfoRequestDto(
+  String name,
+  LocalDate expireDate,
+  String storeName,
+  String memo,
+  boolean isMoneyCoupon,
+  Integer leftMoney
+) {
+}

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/in/response/CouponsResponseDto.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/in/response/CouponsResponseDto.java
@@ -1,11 +1,11 @@
 package yapp.buddycon.web.coupon.adapter.in.response;
 
-import java.util.Date;
+import java.time.LocalDate;
 
-public record GifticonsResponseDto(
+public record CouponsResponseDto(
   Long id,
   String path,
   String name,
-  Date expireDate
+  LocalDate expireDate
 ) {
 }

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/in/response/CustomCouponInfoResponseDto.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/in/response/CustomCouponInfoResponseDto.java
@@ -1,0 +1,13 @@
+package yapp.buddycon.web.coupon.adapter.in.response;
+
+import java.time.LocalDate;
+
+public record CustomCouponInfoResponseDto(
+  String imageUrl,
+  String name,
+  LocalDate expireDate,
+  String storeName,
+  String sentMemberName,
+  String memo
+) {
+}

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/in/response/GifticonInfoResponseDto.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/in/response/GifticonInfoResponseDto.java
@@ -1,0 +1,14 @@
+package yapp.buddycon.web.coupon.adapter.in.response;
+
+import java.time.LocalDate;
+
+public record GifticonInfoResponseDto(
+  String imageUrl,
+  String name,
+  LocalDate expireDate,
+  String storeName,
+  String memo,
+  boolean isMoneyCoupon,
+  Integer leftMoney
+) {
+}

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/in/response/SharedCouponsResponseDto.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/in/response/SharedCouponsResponseDto.java
@@ -1,0 +1,12 @@
+package yapp.buddycon.web.coupon.adapter.in.response;
+
+import java.time.LocalDate;
+
+public record SharedCouponsResponseDto(
+  Long id,
+  String path,
+  String name,
+  LocalDate expireDate,
+  boolean shared
+) {
+}

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/out/CouponJpaRepository.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/out/CouponJpaRepository.java
@@ -1,14 +1,7 @@
 package yapp.buddycon.web.coupon.adapter.out;
 
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-import yapp.buddycon.web.coupon.adapter.in.response.GifticonsResponseDto;
 import yapp.buddycon.web.coupon.domain.Coupon;
-import yapp.buddycon.web.coupon.domain.CouponState;
-
-import java.util.List;
 
 public interface CouponJpaRepository extends JpaRepository<Coupon, Long> {
 


### PR DESCRIPTION
## 개요
coupon 도메인의 mock api 추가

## 작업 내용
- DefaultResponseDto를 common의 response 패키지에 추가하였습니다.
  - success 여부, message 값을 전달합니다. (Post, Put, Patch, Delete등 command요청에서 주로 사용하였습니다.)
- coupon 도메인의 mock api를 추가하였습니다.
  - controller의 코드가 길어져 앞으로 코드가 추가되면 가독성이 안좋아질 듯 합니다.. 추후 클래스 분리를 고려해 봐도 좋을것같습니다

## 메모
x

close #9 
