### PR TITLE
[Issue #25] 멤버 엔티티 컬럼 추가

### DIFF
--- a/src/main/java/yapp/buddycon/web/member/domain/Member.java
+++ b/src/main/java/yapp/buddycon/web/member/domain/Member.java
@@ -14,7 +14,16 @@ public class Member extends BaseEntity {
   @Column(name = "client_id", unique = true)
   private Long clientId;
 
-  @Column(name = "name")
-  private String name;
+  @Column(name = "email", nullable = false)
+  private String email;
+
+  @Column(name = "nickname", nullable = false)
+  private String nickname;
+
+  @Column(name = "gender")
+  private String gender;
+
+  @Column(name = "age_range")
+  private String ageRange;
 
 }


### PR DESCRIPTION
## 개요
멤버 엔티티 컬럼 추가

## 작업 내용
카카오로부터 받아오는 멤버의 이메일, 닉네임, 성별, 연령을 멤버 entity에 추가하였습니다

## 메모

close #25 
