### PR TITLE
[Issue #24] Kakao oauth token 로직의 request 형식 변경

### DIFF
--- a/src/main/java/yapp/buddycon/web/auth/adapter/in/LoginController.java
+++ b/src/main/java/yapp/buddycon/web/auth/adapter/in/LoginController.java
@@ -3,26 +3,29 @@ package yapp.buddycon.web.auth.adapter.in;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import yapp.buddycon.web.auth.adapter.in.request.KakaoInfoRequestDto;
 import yapp.buddycon.web.auth.adapter.in.request.ReissueRequestDto;
 import yapp.buddycon.web.auth.adapter.in.response.TokenResponseDto;
-import yapp.buddycon.web.auth.application.service.AuthService;
+import yapp.buddycon.web.auth.application.port.in.AuthUseCase;
+
+import javax.validation.Valid;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("api/v1/")
+@RequestMapping("api/v1")
 public class LoginController {
 
-  private final AuthService authService;
+  private final AuthUseCase authUseCase;
 
-  @PostMapping("login/{accessToken}")
+  @PostMapping("/login")
   @Operation(summary = "로그인", description = "최초 로그인일 경우 회원가입 처리")
-  public TokenResponseDto login(@PathVariable String accessToken) {
-    return authService.login(accessToken);
+  public TokenResponseDto login(@RequestBody @Valid KakaoInfoRequestDto kakaoInfoRequestDto) {
+    return authUseCase.login(kakaoInfoRequestDto);
   }
 
-  @PostMapping("reissue")
+  @PostMapping("/reissue")
   public TokenResponseDto reissue(@RequestBody ReissueRequestDto reissueRequestDto) {
-    return authService.reissue(reissueRequestDto);
+    return authUseCase.reissue(reissueRequestDto);
   }
 
 }

--- a/src/main/java/yapp/buddycon/web/auth/adapter/in/request/KakaoInfoRequestDto.java
+++ b/src/main/java/yapp/buddycon/web/auth/adapter/in/request/KakaoInfoRequestDto.java
@@ -1,0 +1,17 @@
+package yapp.buddycon.web.auth.adapter.in.request;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotEmpty;
+
+public record KakaoInfoRequestDto(
+  @NotEmpty
+  String accessToken,
+  @Email
+  String email,
+  @NotEmpty
+  String nickname,
+
+  String gender,
+  String ageRange
+) {
+}

--- a/src/main/java/yapp/buddycon/web/auth/adapter/in/request/KakaoInfoRequestDto.java
+++ b/src/main/java/yapp/buddycon/web/auth/adapter/in/request/KakaoInfoRequestDto.java
@@ -9,7 +9,7 @@ public record KakaoInfoRequestDto(
   @Email
   String email,
   @NotEmpty
-  String nickname,
+  String name,
 
   String gender,
   String ageRange

--- a/src/main/java/yapp/buddycon/web/auth/application/port/in/AuthUseCase.java
+++ b/src/main/java/yapp/buddycon/web/auth/application/port/in/AuthUseCase.java
@@ -1,7 +1,10 @@
 package yapp.buddycon.web.auth.application.port.in;
 
+import yapp.buddycon.web.auth.adapter.in.request.KakaoInfoRequestDto;
+import yapp.buddycon.web.auth.adapter.in.request.ReissueRequestDto;
 import yapp.buddycon.web.auth.adapter.in.response.TokenResponseDto;
 
 public interface AuthUseCase {
-  TokenResponseDto login(String accessToken);
+  TokenResponseDto login(KakaoInfoRequestDto kakaoInfoRequestDto);
+  TokenResponseDto reissue(ReissueRequestDto reissueRequestDto);
 }

--- a/src/main/java/yapp/buddycon/web/auth/application/port/in/OAuthMemberInfo.java
+++ b/src/main/java/yapp/buddycon/web/auth/application/port/in/OAuthMemberInfo.java
@@ -1,7 +1,6 @@
 package yapp.buddycon.web.auth.application.port.in;
 
 public record OAuthMemberInfo(
-  Long id,
-  String nickname
+  Long id
 ) {
 }

--- a/src/main/java/yapp/buddycon/web/auth/application/service/AuthService.java
+++ b/src/main/java/yapp/buddycon/web/auth/application/service/AuthService.java
@@ -30,12 +30,14 @@ public class AuthService implements AuthUseCase {
   public TokenResponseDto login(KakaoInfoRequestDto kakaoInfoRequestDto) {
     OAuthMemberInfo oAuthMemberInfo = kakaoOAuthMapper.getUserAttributes(kakaoInfoRequestDto.accessToken());
     Member member = authToMemberQueryPort.findMemberByClientId(oAuthMemberInfo.id());
-    if (member == null) member = signup(oAuthMemberInfo, kakaoInfoRequestDto);
+    if (member == null){
+      member = Member.create(oAuthMemberInfo.id(), kakaoInfoRequestDto.email(), kakaoInfoRequestDto.name(), kakaoInfoRequestDto.gender(), kakaoInfoRequestDto.ageRange());
+    }
     return tokenProvider.createToken(member.getId());
   }
 
   private Member signup(OAuthMemberInfo oAuthMemberInfo, KakaoInfoRequestDto kakaoInfoRequestDto) {
-    return authToMemberCommandPort.save(new Member(oAuthMemberInfo.id(), kakaoInfoRequestDto.email(), kakaoInfoRequestDto.nickname(), kakaoInfoRequestDto.gender(), kakaoInfoRequestDto.ageRange()));
+    return authToMemberCommandPort.save(new Member(oAuthMemberInfo.id(), kakaoInfoRequestDto.email(), kakaoInfoRequestDto.name(), kakaoInfoRequestDto.gender(), kakaoInfoRequestDto.ageRange()));
   }
 
   @Transactional

--- a/src/main/java/yapp/buddycon/web/auth/application/service/AuthService.java
+++ b/src/main/java/yapp/buddycon/web/auth/application/service/AuthService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import yapp.buddycon.common.exception.CustomException;
 import yapp.buddycon.common.exception.ErrorCode;
+import yapp.buddycon.web.auth.adapter.in.request.KakaoInfoRequestDto;
 import yapp.buddycon.web.auth.adapter.in.request.ReissueRequestDto;
 import yapp.buddycon.web.auth.application.port.out.AuthToMemberCommandPort;
 import yapp.buddycon.web.auth.application.port.out.AuthToMemberQueryPort;
@@ -26,15 +27,15 @@ public class AuthService implements AuthUseCase {
   private final AuthToMemberCommandPort authToMemberCommandPort;
 
   @Transactional
-  public TokenResponseDto login(String accessToken) {
-    OAuthMemberInfo oAuthMemberInfo = kakaoOAuthMapper.getUserAttributes(accessToken);
+  public TokenResponseDto login(KakaoInfoRequestDto kakaoInfoRequestDto) {
+    OAuthMemberInfo oAuthMemberInfo = kakaoOAuthMapper.getUserAttributes(kakaoInfoRequestDto.accessToken());
     Member member = authToMemberQueryPort.findMemberByClientId(oAuthMemberInfo.id());
-    if (member == null) member = signup(oAuthMemberInfo);
+    if (member == null) member = signup(oAuthMemberInfo, kakaoInfoRequestDto);
     return tokenProvider.createToken(member.getId());
   }
 
-  private Member signup(OAuthMemberInfo oAuthMemberInfo) {
-    return authToMemberCommandPort.save(new Member(oAuthMemberInfo.id(), oAuthMemberInfo.nickname()));
+  private Member signup(OAuthMemberInfo oAuthMemberInfo, KakaoInfoRequestDto kakaoInfoRequestDto) {
+    return authToMemberCommandPort.save(new Member(oAuthMemberInfo.id(), kakaoInfoRequestDto.email(), kakaoInfoRequestDto.nickname(), kakaoInfoRequestDto.gender(), kakaoInfoRequestDto.ageRange()));
   }
 
   @Transactional

--- a/src/main/java/yapp/buddycon/web/auth/application/service/KakaoOAuthMapper.java
+++ b/src/main/java/yapp/buddycon/web/auth/application/service/KakaoOAuthMapper.java
@@ -25,17 +25,11 @@ public class KakaoOAuthMapper {
 
   @JsonIgnoreProperties(ignoreUnknown = true)
   record Kakao(
-    Long id,
-    KakaoNickname properties
+    Long id
   ){
     public OAuthMemberInfo toOAuthMember(){
-      return new OAuthMemberInfo(id, properties().nickname());
+      return new OAuthMemberInfo(id);
     }
   }
-
-  @JsonIgnoreProperties(ignoreUnknown = true)
-  record KakaoNickname(
-    String nickname
-  ){}
 
 }

--- a/src/main/java/yapp/buddycon/web/member/domain/Member.java
+++ b/src/main/java/yapp/buddycon/web/member/domain/Member.java
@@ -1,6 +1,7 @@
 package yapp.buddycon.web.member.domain;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
 import yapp.buddycon.common.domain.BaseEntity;
 
@@ -9,12 +10,32 @@ import javax.persistence.*;
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 public class Member extends BaseEntity {
 
   @Column(name = "client_id", unique = true)
   private Long clientId;
 
+  @Column(name = "email", nullable = false)
+  private String email;
+
   @Column(name = "name")
   private String name;
+
+  @Column(name = "gender")
+  private String gender;
+
+  @Column(name = "age_range")
+  private String ageRange;
+
+  public static Member create(Long clientId, String email, String name, String gender, String ageRange) {
+    return Member.builder()
+      .clientId(clientId)
+      .email(email)
+      .name(name)
+      .gender(gender)
+      .ageRange(ageRange)
+      .build();
+  }
 
 }


### PR DESCRIPTION
## 개요
Kakao oauth token 로직의 request 형식 변경

## 작업 내용
멤버의 카카오 정보(이메일, 닉네임, 성별, 연령대)를 프론트 측에서 보내주시고 있기 때문에, 그에 맞춰 request 형식을 변경하였습니다.

## 메모

close #24 
