### PR TITLE
[Issue #28] 쿠폰 정렬 조회

### DIFF
--- a/src/main/java/yapp/buddycon/common/exception/ErrorCode.java
+++ b/src/main/java/yapp/buddycon/common/exception/ErrorCode.java
@@ -21,6 +21,8 @@ public enum ErrorCode {
   LOGGED_OUT_MEMBER(BAD_REQUEST, "로그아웃된 사용자입니다."),
   TOKEN_MEMBER_INFO_IS_NOT_MATCH(BAD_REQUEST, "토큰의 사용자 정보가 일치하지 않습니다."),
 
+  INVALID_SORT_PROPERTY(BAD_REQUEST, "잘못된 sort 방식입니다."),
+
   ;
 
   private final HttpStatus httpStatus;

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/in/CouponController.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/in/CouponController.java
@@ -64,15 +64,15 @@ public class CouponController {
     return null;
   }
 
-  @GetMapping("/gifticon/{barcode}")
+  @GetMapping("/gifticon/info")
   @Operation(summary = "바코드로 기프티콘 정보 불러오기")
-  public GifticonInfoResponseDto getGifticonInfoByBarcode(@PathVariable("barcode") String barcode, AuthMember authMember) {
+  public GifticonInfoResponseDto getGifticonInfoByBarcode(@RequestParam("barcode") String barcode, AuthMember authMember) {
     return null;
   }
 
-  @GetMapping("/custom-coupon/{barcode}")
+  @GetMapping("/custom-coupon/info")
   @Operation(summary = "바코드로 제작티콘 정보 불러오기")
-  public CustomCouponInfoResponseDto getCustomCouponInfoByBarcode(@PathVariable("barcode") String barcode, AuthMember authMember) {
+  public CustomCouponInfoResponseDto getCustomCouponInfoByBarcode(@RequestParam("barcode") String barcode, AuthMember authMember) {
     return null;
   }
 

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/in/CouponController.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/in/CouponController.java
@@ -25,13 +25,13 @@ public class CouponController {
   @GetMapping("/gifticon")
   @Operation(summary = "기프티콘 정렬 조회")
   public List<CouponsResponseDto> getSortedGifticons(@RequestParam("usable") boolean usable, Pageable pageable, AuthMember authMember) {
-    return null;
+    return couponUseCase.getSortedGifticons(usable, pageable, authMember);
   }
 
   @GetMapping("/custom-coupon")
   @Operation(summary = "제작티콘 정렬 조회")
   public List<CouponsResponseDto> getSortedCustomCoupons(@RequestParam("usable") boolean usable, Pageable pageable, AuthMember authMember) {
-    return null;
+    return couponUseCase.getSortedCustomCoupons(usable, pageable, authMember);
   }
 
   @GetMapping("/gifticon/{id}")

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/in/response/CouponsResponseDto.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/in/response/CouponsResponseDto.java
@@ -4,7 +4,7 @@ import java.time.LocalDate;
 
 public record CouponsResponseDto(
   Long id,
-  String path,
+  String imageUrl,
   String name,
   LocalDate expireDate
 ) {

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/out/CouponJpaRepository.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/out/CouponJpaRepository.java
@@ -1,8 +1,33 @@
 package yapp.buddycon.web.coupon.adapter.out;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import yapp.buddycon.web.coupon.adapter.in.response.CouponsResponseDto;
 import yapp.buddycon.web.coupon.domain.Coupon;
+import yapp.buddycon.web.coupon.domain.CouponState;
+
+import java.util.List;
 
 public interface CouponJpaRepository extends JpaRepository<Coupon, Long> {
+
+  @Query(value = """
+    select new yapp.buddycon.web.coupon.adapter.in.response.CouponsResponseDto(c.id, c.couponInfo.imageUrl, c.couponInfo.name, c.couponInfo.expireDate)
+    from Coupon c
+    where c.state = :state
+    and c.couponType = 'REAL'
+    and c.member.id = :memberId
+  """)
+  List<CouponsResponseDto> findSortedGifticonsAccordingToState(@Param("state") CouponState state, Long memberId, Pageable pageable);
+
+  @Query(value = """
+    select new yapp.buddycon.web.coupon.adapter.in.response.CouponsResponseDto(c.id, c.couponInfo.imageUrl, c.couponInfo.name, c.couponInfo.expireDate)
+    from Coupon c
+    where c.state = :state
+    and c.couponType = 'CUSTOM'
+    and c.member.id = :memberId
+  """)
+  List<CouponsResponseDto> findSortedCustomCouponsAccordingToState(@Param("state") CouponState state, Long memberId, Pageable pageable);
 
 }

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/out/CouponQueryRepository.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/out/CouponQueryRepository.java
@@ -1,14 +1,39 @@
 package yapp.buddycon.web.coupon.adapter.out;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
+import yapp.buddycon.web.coupon.adapter.in.response.CouponsResponseDto;
 import yapp.buddycon.web.coupon.application.port.out.CouponQueryPort;
 import yapp.buddycon.web.coupon.domain.CouponState;
+
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
 public class CouponQueryRepository implements CouponQueryPort {
 
   private final CouponJpaRepository couponJpaRepository;
+
+  @Override
+  public List<CouponsResponseDto> findUsableGifticonsSortedBy(Pageable pageable, Long memberId) {
+    return couponJpaRepository.findSortedGifticonsAccordingToState(CouponState.USABLE, memberId, pageable);
+  }
+
+  @Override
+  public List<CouponsResponseDto> findUsedGifticonsSortedBy(Pageable pageable, Long memberId) {
+    return couponJpaRepository.findSortedGifticonsAccordingToState(CouponState.USED, memberId, pageable);
+  }
+
+  @Override
+  public List<CouponsResponseDto> findUsableCustomCouponsSortedBy(Pageable pageable, Long memberId) {
+    return couponJpaRepository.findSortedCustomCouponsAccordingToState(CouponState.USABLE, memberId, pageable);
+  }
+
+  @Override
+  public List<CouponsResponseDto> findUsedCustomCouponsSortedBy(Pageable pageable, Long memberId) {
+    return couponJpaRepository.findSortedCustomCouponsAccordingToState(CouponState.USED, memberId, pageable);
+  }
+
 
 }

--- a/src/main/java/yapp/buddycon/web/coupon/application/port/in/CouponUseCase.java
+++ b/src/main/java/yapp/buddycon/web/coupon/application/port/in/CouponUseCase.java
@@ -1,4 +1,15 @@
 package yapp.buddycon.web.coupon.application.port.in;
 
+import org.springframework.data.domain.Pageable;
+import yapp.buddycon.web.auth.adapter.out.AuthMember;
+import yapp.buddycon.web.coupon.adapter.in.response.CouponsResponseDto;
+
+import java.util.List;
+
 public interface CouponUseCase {
+
+  List<CouponsResponseDto> getSortedGifticons(boolean usable, Pageable pageable, AuthMember authMember);
+
+  List<CouponsResponseDto> getSortedCustomCoupons(boolean usable, Pageable pageable, AuthMember authMember);
+
 }

--- a/src/main/java/yapp/buddycon/web/coupon/application/port/out/CouponQueryPort.java
+++ b/src/main/java/yapp/buddycon/web/coupon/application/port/out/CouponQueryPort.java
@@ -1,4 +1,15 @@
 package yapp.buddycon.web.coupon.application.port.out;
 
+import org.springframework.data.domain.Pageable;
+import yapp.buddycon.web.coupon.adapter.in.response.CouponsResponseDto;
+
+import java.util.List;
+
 public interface CouponQueryPort {
+
+  List<CouponsResponseDto> findUsableGifticonsSortedBy(Pageable pageable, Long memberId);
+  List<CouponsResponseDto> findUsedGifticonsSortedBy(Pageable pageable, Long memberId);
+
+  List<CouponsResponseDto> findUsableCustomCouponsSortedBy(Pageable pageable, Long memberId);
+  List<CouponsResponseDto> findUsedCustomCouponsSortedBy(Pageable pageable, Long memberId);
 }

--- a/src/main/java/yapp/buddycon/web/coupon/application/service/CouponService.java
+++ b/src/main/java/yapp/buddycon/web/coupon/application/service/CouponService.java
@@ -1,10 +1,15 @@
 package yapp.buddycon.web.coupon.application.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import yapp.buddycon.web.auth.adapter.out.AuthMember;
+import yapp.buddycon.web.coupon.adapter.in.response.CouponsResponseDto;
 import yapp.buddycon.web.coupon.application.port.in.CouponUseCase;
 import yapp.buddycon.web.coupon.application.port.out.CouponCommandPort;
 import yapp.buddycon.web.coupon.application.port.out.CouponQueryPort;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -13,5 +18,23 @@ public class CouponService implements CouponUseCase {
   private final CouponCommandPort couponCommandPort;
   private final CouponQueryPort couponQueryPort;
 
+  @Override
+  public List<CouponsResponseDto> getSortedGifticons(boolean usable, Pageable pageable, AuthMember authMember) {
+    if(usable) return couponQueryPort.findUsableGifticonsSortedBy(pageable, authMember.id());
+    return couponQueryPort.findUsedGifticonsSortedBy(pageable, authMember.id());
+  }
+
+  @Override
+  public List<CouponsResponseDto> getSortedCustomCoupons(boolean usable, Pageable pageable, AuthMember authMember) {
+    if(usable) return couponQueryPort.findUsableCustomCouponsSortedBy(pageable, authMember.id());
+    return couponQueryPort.findUsedCustomCouponsSortedBy(pageable, authMember.id());
+  }
+
+  /*
+  유효기간순 -> expireDate ASC
+  등록순 -> createdAt ASC
+  이름순 -> name ASC
+  page=3&size=10&sort=couponInfo.expireDate,DESC
+  */
 
 }

--- a/src/main/java/yapp/buddycon/web/coupon/application/service/CouponService.java
+++ b/src/main/java/yapp/buddycon/web/coupon/application/service/CouponService.java
@@ -1,7 +1,9 @@
 package yapp.buddycon.web.coupon.application.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import yapp.buddycon.web.auth.adapter.out.AuthMember;
 import yapp.buddycon.web.coupon.adapter.in.response.CouponsResponseDto;
@@ -20,14 +22,18 @@ public class CouponService implements CouponUseCase {
 
   @Override
   public List<CouponsResponseDto> getSortedGifticons(boolean usable, Pageable pageable, AuthMember authMember) {
-    if(usable) return couponQueryPort.findUsableGifticonsSortedBy(pageable, authMember.id());
-    return couponQueryPort.findUsedGifticonsSortedBy(pageable, authMember.id());
+    Sort sort = SortPageableValidation.validateSortProperty(pageable.getSort().toString());
+    PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
+    if(usable) return couponQueryPort.findUsableGifticonsSortedBy(pageRequest, authMember.id());
+    return couponQueryPort.findUsedGifticonsSortedBy(pageRequest, authMember.id());
   }
 
   @Override
   public List<CouponsResponseDto> getSortedCustomCoupons(boolean usable, Pageable pageable, AuthMember authMember) {
-    if(usable) return couponQueryPort.findUsableCustomCouponsSortedBy(pageable, authMember.id());
-    return couponQueryPort.findUsedCustomCouponsSortedBy(pageable, authMember.id());
+    Sort sort = SortPageableValidation.validateSortProperty(pageable.getSort().toString());
+    PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
+    if(usable) return couponQueryPort.findUsableCustomCouponsSortedBy(pageRequest, authMember.id());
+    return couponQueryPort.findUsedCustomCouponsSortedBy(pageRequest, authMember.id());
   }
 
   /*

--- a/src/main/java/yapp/buddycon/web/coupon/application/service/SortPageableValidation.java
+++ b/src/main/java/yapp/buddycon/web/coupon/application/service/SortPageableValidation.java
@@ -1,0 +1,29 @@
+package yapp.buddycon.web.coupon.application.service;
+
+import org.springframework.data.domain.Sort;
+import yapp.buddycon.common.exception.CustomException;
+import yapp.buddycon.common.exception.ErrorCode;
+
+import java.util.Arrays;
+
+public enum SortPageableValidation {
+  CREATED_AT_ASC_SORT("createdAt: ASC", Sort.by("createdAt").ascending()),
+  EXPIRE_DATE_ASC_SORT("expireDate: ASC", Sort.by("couponInfo.expireDate").ascending()),
+  NAME_ASC_SORT("name: ASC", Sort.by("couponInfo.name").ascending());
+
+  private String inputSortProperty;
+  private Sort sort;
+
+  SortPageableValidation(String inputSortProperty, Sort sort) {
+    this.inputSortProperty = inputSortProperty;
+    this.sort = sort;
+  }
+
+  public static Sort validateSortProperty(String input) {
+    return Arrays.stream(SortPageableValidation.values())
+      .filter(it -> it.inputSortProperty.equals(input))
+      .map(it -> it.sort)
+      .findAny()
+      .orElseThrow(() -> new CustomException(ErrorCode.INVALID_SORT_PROPERTY));
+  }
+}


### PR DESCRIPTION
## 개요
기프티콘, 제작티콘의 쿠폰 정렬 조회 api 구현

## 작업 내용
<img width="400" alt="스크린샷 2023-01-26 오후 9 11 08" src="https://user-images.githubusercontent.com/69676101/214832150-2a181e53-eaf5-4b5a-a9e5-f485e1cddb50.png">

<img width="400" alt="스크린샷 2023-01-26 오후 9 24 17" src="https://user-images.githubusercontent.com/69676101/214834662-ec88221b-7a34-4a55-8c29-f06fe89806e7.png">

- page 처리를 통해 위 화면에 해당하는 api를 구현하였습니다.
- pageable의 sort에서는 entity의 embedded내부 속성을 불러들이지 못하는걸로 보입니다.
- 따라서 현재 embedded내부 필드(name, expireDate)의 Pageable 요청 포맷은
  - page=3&size=10&sort=couponInfo.expireDate,DESC
- 와 같이 embedded클래스의 이름(couponInfo)을 포함하여 요청해야합니다.

## 메모
- 구글링을 아무리해봐도 나오는 정보가 그다지 없어서 우선 위와같은 포맷으로 프론트분들께 요청드리려 합니다.
- 혹시 현희님 이부분에 대해 알고계신다면ㅜㅜ 리뷰 부탁드립니다.

close #28 
