### PR TITLE
[Issue #32] 쿠폰 상세 조회

### DIFF
--- a/src/main/java/yapp/buddycon/web/coupon/adapter/in/CouponController.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/in/CouponController.java
@@ -37,13 +37,13 @@ public class CouponController {
   @GetMapping("/gifticon/{id}")
   @Operation(summary = "기프티콘 상세 조회")
   public GifticonInfoResponseDto getGifticonInfo(@PathVariable("id") long id, AuthMember authMember) {
-    return null;
+    return couponUseCase.getGifticonInfo(authMember.id(), id);
   }
 
   @GetMapping("/custom-coupon/{id}")
   @Operation(summary = "제작티콘 상세 조회")
   public CustomCouponInfoResponseDto getCustomCouponInfo(@PathVariable("id") long id, AuthMember authMember) {
-    return null;
+    return couponUseCase.getCustomCouponInfo(authMember.id(), id);
   }
 
   @PatchMapping("/{id}/state")

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/in/CouponController.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/in/CouponController.java
@@ -36,19 +36,19 @@ public class CouponController {
 
   @GetMapping("/gifticon/{id}")
   @Operation(summary = "기프티콘 상세 조회")
-  public GifticonInfoResponseDto getGifticonInfo(@PathVariable("id") long id) {
+  public GifticonInfoResponseDto getGifticonInfo(@PathVariable("id") long id, AuthMember authMember) {
     return null;
   }
 
   @GetMapping("/custom-coupon/{id}")
   @Operation(summary = "제작티콘 상세 조회")
-  public CustomCouponInfoResponseDto getCustomCouponInfo(@PathVariable("id") long id) {
+  public CustomCouponInfoResponseDto getCustomCouponInfo(@PathVariable("id") long id, AuthMember authMember) {
     return null;
   }
 
   @PatchMapping("/{id}/state")
   @Operation(summary = "쿠폰 상태 변경", description = "상태 : USED, USABLE")
-  public DefaultResponseDto changeCouponState(@PathVariable("id") long id, @RequestBody CouponStateRequestDto couponStateRequestDto) {
+  public DefaultResponseDto changeCouponState(@PathVariable("id") long id, @RequestBody CouponStateRequestDto couponStateRequestDto, AuthMember authMember) {
     return null;
   }
 
@@ -78,19 +78,19 @@ public class CouponController {
 
   @DeleteMapping("/{id}")
   @Operation(summary = "쿠폰 삭제")
-  public DefaultResponseDto deleteCoupon(@PathVariable("id") long id) {
+  public DefaultResponseDto deleteCoupon(@PathVariable("id") long id, AuthMember authMember) {
     return null;
   }
 
   @PutMapping("/gifticon/{id}")
   @Operation(summary = "기프티콘 정보 수정")
-  public DefaultResponseDto editGifticonInfo(@PathVariable("id") long id, @RequestBody GifticonInfoRequestDto gifticonInfoRequestDto) {
+  public DefaultResponseDto editGifticonInfo(@PathVariable("id") long id, @RequestBody GifticonInfoRequestDto gifticonInfoRequestDto, AuthMember authMember) {
     return null;
   }
 
   @PutMapping("/custom-coupon/{id}")
   @Operation(summary = "제작티콘 정보 수정")
-  public DefaultResponseDto editCustomCouponInfo(@PathVariable("id") long id, @RequestBody CustomCouponInfoRequestDto customCouponInfoRequestDto) {
+  public DefaultResponseDto editCustomCouponInfo(@PathVariable("id") long id, @RequestBody CustomCouponInfoRequestDto customCouponInfoRequestDto, AuthMember authMember) {
     return null;
   }
 

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/in/response/CustomCouponInfoResponseDto.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/in/response/CustomCouponInfoResponseDto.java
@@ -3,6 +3,7 @@ package yapp.buddycon.web.coupon.adapter.in.response;
 import java.time.LocalDate;
 
 public record CustomCouponInfoResponseDto(
+  Long id,
   String imageUrl,
   String barcode,
   String name,

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/in/response/GifticonInfoResponseDto.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/in/response/GifticonInfoResponseDto.java
@@ -3,6 +3,7 @@ package yapp.buddycon.web.coupon.adapter.in.response;
 import java.time.LocalDate;
 
 public record GifticonInfoResponseDto(
+  Long id,
   String imageUrl,
   String barcode,
   String name,

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/out/CouponJpaRepository.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/out/CouponJpaRepository.java
@@ -9,7 +9,7 @@ import yapp.buddycon.web.coupon.domain.Coupon;
 public interface CouponJpaRepository extends JpaRepository<Coupon, Long> {
 
   @Query(value = """
-    select new yapp.buddycon.web.coupon.adapter.in.response.GifticonInfoResponseDto(c.couponInfo.imageUrl, c.couponInfo.barcode, c.couponInfo.name, c.couponInfo.expireDate, c.couponInfo.storeName, c.couponInfo.memo, c.couponInfo.isMoneyCoupon, c.couponInfo.leftMoney)
+    select new yapp.buddycon.web.coupon.adapter.in.response.GifticonInfoResponseDto(c.id, c.couponInfo.imageUrl, c.couponInfo.barcode, c.couponInfo.name, c.couponInfo.expireDate, c.couponInfo.storeName, c.couponInfo.memo, c.couponInfo.isMoneyCoupon, c.couponInfo.leftMoney)
     from Coupon c
     where c.member.id = :memberId
     and c.id = :id
@@ -18,7 +18,7 @@ public interface CouponJpaRepository extends JpaRepository<Coupon, Long> {
   GifticonInfoResponseDto findGifticonByMemberIdAndIdAndCouponType(Long memberId, Long id);
 
   @Query(value = """
-    select new yapp.buddycon.web.coupon.adapter.in.response.CustomCouponInfoResponseDto(c.couponInfo.imageUrl, c.couponInfo.barcode, c.couponInfo.name, c.couponInfo.expireDate, c.couponInfo.storeName, c.couponInfo.sentMemberName, c.couponInfo.memo)
+    select new yapp.buddycon.web.coupon.adapter.in.response.CustomCouponInfoResponseDto(c.id, c.couponInfo.imageUrl, c.couponInfo.barcode, c.couponInfo.name, c.couponInfo.expireDate, c.couponInfo.storeName, c.couponInfo.sentMemberName, c.couponInfo.memo)
     from Coupon c
     where c.member.id = :memberId
     and c.id = :id

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/out/CouponJpaRepository.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/out/CouponJpaRepository.java
@@ -1,8 +1,29 @@
 package yapp.buddycon.web.coupon.adapter.out;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import yapp.buddycon.web.coupon.adapter.in.response.CustomCouponInfoResponseDto;
+import yapp.buddycon.web.coupon.adapter.in.response.GifticonInfoResponseDto;
 import yapp.buddycon.web.coupon.domain.Coupon;
 
 public interface CouponJpaRepository extends JpaRepository<Coupon, Long> {
+
+  @Query(value = """
+    select new yapp.buddycon.web.coupon.adapter.in.response.GifticonInfoResponseDto(c.couponInfo.imageUrl, c.couponInfo.barcode, c.couponInfo.name, c.couponInfo.expireDate, c.couponInfo.storeName, c.couponInfo.memo, c.couponInfo.isMoneyCoupon, c.couponInfo.leftMoney)
+    from Coupon c
+    where c.member.id = :memberId
+    and c.id = :id
+    and c.couponType = 'REAL'
+  """)
+  GifticonInfoResponseDto findGifticonByMemberIdAndIdAndCouponType(Long memberId, Long id);
+
+  @Query(value = """
+    select new yapp.buddycon.web.coupon.adapter.in.response.CustomCouponInfoResponseDto(c.couponInfo.imageUrl, c.couponInfo.barcode, c.couponInfo.name, c.couponInfo.expireDate, c.couponInfo.storeName, c.couponInfo.sentMemberName, c.couponInfo.memo)
+    from Coupon c
+    where c.member.id = :memberId
+    and c.id = :id
+    and c.couponType = 'CUSTOM'
+  """)
+  CustomCouponInfoResponseDto findCustomCouponByMemberIdAndIdAndCouponType(Long memberId, Long id);
 
 }

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/out/CouponQueryRepository.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/out/CouponQueryRepository.java
@@ -2,8 +2,9 @@ package yapp.buddycon.web.coupon.adapter.out;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import yapp.buddycon.web.coupon.adapter.in.response.CustomCouponInfoResponseDto;
+import yapp.buddycon.web.coupon.adapter.in.response.GifticonInfoResponseDto;
 import yapp.buddycon.web.coupon.application.port.out.CouponQueryPort;
-import yapp.buddycon.web.coupon.domain.CouponState;
 
 @Repository
 @RequiredArgsConstructor
@@ -11,4 +12,13 @@ public class CouponQueryRepository implements CouponQueryPort {
 
   private final CouponJpaRepository couponJpaRepository;
 
+  @Override
+  public GifticonInfoResponseDto findGifticonInfo(Long memberId, Long couponId) {
+    return couponJpaRepository.findGifticonByMemberIdAndIdAndCouponType(memberId, couponId);
+  }
+
+  @Override
+  public CustomCouponInfoResponseDto findCustomCouponInfo(Long memberId, Long couponId) {
+    return couponJpaRepository.findCustomCouponByMemberIdAndIdAndCouponType(memberId, couponId);
+  }
 }

--- a/src/main/java/yapp/buddycon/web/coupon/application/port/in/CouponUseCase.java
+++ b/src/main/java/yapp/buddycon/web/coupon/application/port/in/CouponUseCase.java
@@ -1,4 +1,11 @@
 package yapp.buddycon.web.coupon.application.port.in;
 
+import yapp.buddycon.web.coupon.adapter.in.response.CustomCouponInfoResponseDto;
+import yapp.buddycon.web.coupon.adapter.in.response.GifticonInfoResponseDto;
+
 public interface CouponUseCase {
+
+  GifticonInfoResponseDto getGifticonInfo(Long memberId, Long couponId);
+
+  CustomCouponInfoResponseDto getCustomCouponInfo(Long memberId, Long couponId);
 }

--- a/src/main/java/yapp/buddycon/web/coupon/application/port/out/CouponQueryPort.java
+++ b/src/main/java/yapp/buddycon/web/coupon/application/port/out/CouponQueryPort.java
@@ -1,4 +1,10 @@
 package yapp.buddycon.web.coupon.application.port.out;
 
+import yapp.buddycon.web.coupon.adapter.in.response.CustomCouponInfoResponseDto;
+import yapp.buddycon.web.coupon.adapter.in.response.GifticonInfoResponseDto;
+
 public interface CouponQueryPort {
+
+  GifticonInfoResponseDto findGifticonInfo(Long memberId, Long couponId);
+  CustomCouponInfoResponseDto findCustomCouponInfo(Long memberId, Long couponId);
 }

--- a/src/main/java/yapp/buddycon/web/coupon/application/service/CouponService.java
+++ b/src/main/java/yapp/buddycon/web/coupon/application/service/CouponService.java
@@ -2,6 +2,8 @@ package yapp.buddycon.web.coupon.application.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import yapp.buddycon.web.coupon.adapter.in.response.CustomCouponInfoResponseDto;
+import yapp.buddycon.web.coupon.adapter.in.response.GifticonInfoResponseDto;
 import yapp.buddycon.web.coupon.application.port.in.CouponUseCase;
 import yapp.buddycon.web.coupon.application.port.out.CouponCommandPort;
 import yapp.buddycon.web.coupon.application.port.out.CouponQueryPort;
@@ -14,4 +16,13 @@ public class CouponService implements CouponUseCase {
   private final CouponQueryPort couponQueryPort;
 
 
+  @Override
+  public GifticonInfoResponseDto getGifticonInfo(Long memberId, Long couponId) {
+    return couponQueryPort.findGifticonInfo(memberId, couponId);
+  }
+
+  @Override
+  public CustomCouponInfoResponseDto getCustomCouponInfo(Long memberId, Long couponId) {
+    return couponQueryPort.findCustomCouponInfo(memberId, couponId);
+  }
 }


### PR DESCRIPTION
## 개요
기프티콘, 제작티콘의 상세 조회 api 구현

## 작업 내용

|기프티콘 상세화면|제작티콘 상세화면|
|---|---|
|<img width="400" alt="스크린샷 2023-01-27 오후 7 19 25" src="https://user-images.githubusercontent.com/69676101/215062846-7d89501b-d76f-467e-a660-b277ee0a0b45.png">|<img width="400" alt="스크린샷 2023-01-27 오후 7 20 37" src="https://user-images.githubusercontent.com/69676101/215063074-8a6b6951-f331-407c-a872-67ee928c975d.png">|

- 기프티콘, 제작티콘의 상세 조회 api를 구현하였습니다.
- id가 pathvariable로 받아온 id와 동일하며, memberId가 authmember id와 동일한 쿠폰을 반환합니다.

## 메모

close #32 
