### PR TITLE
[Issue #16] 알림 상세 조회 API 추가

### DIFF
--- a/src/main/java/yapp/buddycon/common/exception/ErrorCode.java
+++ b/src/main/java/yapp/buddycon/common/exception/ErrorCode.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
 
 @Getter
 @AllArgsConstructor
@@ -24,6 +25,10 @@ public enum ErrorCode {
   INVALID_SORT_PROPERTY(BAD_REQUEST, "잘못된 sort 방식입니다."),
 
   INVALID_COUPON_ID(BAD_REQUEST, "해당 쿠폰 id가 존재하지 않습니다."),
+  INVALID_NOTIFICATION_ID(BAD_REQUEST, "해당 알림 id가 존재하지 않습니다."),
+
+  /* 403 FORBIDDEN */
+  CANT_ACCESS_NOTIFICATION(FORBIDDEN, "해당 알림에 대한 권한이 없습니다."),
 
   ;
 

--- a/src/main/java/yapp/buddycon/web/coupon/domain/Coupon.java
+++ b/src/main/java/yapp/buddycon/web/coupon/domain/Coupon.java
@@ -1,6 +1,7 @@
 package yapp.buddycon.web.coupon.domain;
 
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import yapp.buddycon.common.domain.BaseEntity;
 import yapp.buddycon.web.member.domain.Member;
@@ -8,6 +9,7 @@ import yapp.buddycon.web.member.domain.Member;
 import javax.persistence.*;
 
 @Entity
+@Getter
 @AllArgsConstructor
 @NoArgsConstructor
 public class Coupon extends BaseEntity {

--- a/src/main/java/yapp/buddycon/web/coupon/domain/CouponInfo.java
+++ b/src/main/java/yapp/buddycon/web/coupon/domain/CouponInfo.java
@@ -3,8 +3,10 @@ package yapp.buddycon.web.coupon.domain;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import java.time.LocalDate;
+import lombok.Getter;
 
 @Embeddable
+@Getter
 public class CouponInfo {
 
   @Column(name = "barcode", nullable = false)

--- a/src/main/java/yapp/buddycon/web/notification/adapter/in/NotificationController.java
+++ b/src/main/java/yapp/buddycon/web/notification/adapter/in/NotificationController.java
@@ -10,25 +10,28 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import yapp.buddycon.web.auth.adapter.out.AuthMember;
 import yapp.buddycon.web.notification.adapter.in.response.NotificationResponseDto;
+import yapp.buddycon.web.notification.application.port.in.NotificationUseCase;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("api/v1/notification")
 public class NotificationController {
 
+  private final NotificationUseCase notificationUseCase;
+
   @GetMapping("")
-  @Operation(summary = "알림 목록 조회", description = "알림 목록 조회 및 확인 완료 처리")
+  @Operation(summary = "알림 정렬 조회", description = "알림 목록 조회 및 확인 완료 처리")
   public List<NotificationResponseDto> getNotifications(AuthMember authMember,
       Pageable pageable) {
     List<NotificationResponseDto> result = null;
     return result;
   }
 
-  @GetMapping("/{notification-id}")
+  @GetMapping("/{id}")
   @Operation(summary = "알림 상세 조회")
-  public NotificationResponseDto getNotification(AuthMember authMember,
-      @PathVariable(value = "notification-id") Long notificationId) {
-    NotificationResponseDto result = null;
+  public NotificationResponseDto getNotificationInfo(AuthMember authMember,
+      @PathVariable(value = "id") Long id) {
+    NotificationResponseDto result = notificationUseCase.getNotification(authMember.id(), id);
     return result;
   }
 

--- a/src/main/java/yapp/buddycon/web/notification/adapter/in/response/NotificationResponseDto.java
+++ b/src/main/java/yapp/buddycon/web/notification/adapter/in/response/NotificationResponseDto.java
@@ -2,6 +2,7 @@ package yapp.buddycon.web.notification.adapter.in.response;
 
 import java.time.LocalDate;
 import yapp.buddycon.web.coupon.domain.CouponType;
+import yapp.buddycon.web.notification.domain.Notification;
 
 public record NotificationResponseDto(
     // notification
@@ -16,5 +17,22 @@ public record NotificationResponseDto(
     String couponName,
     LocalDate expireDate
 ) {
+
+  public static NotificationResponseDto valueOf(Notification notification) {
+    return new NotificationResponseDto(
+        notification.getId(),
+        notification.getTitle(),
+        notification.getBody(),
+        notification.isChecked(),
+        notification.getCoupon() == null ? null :
+            notification.getCoupon().getId(),
+        notification.getCoupon() == null ? null :
+            notification.getCoupon().getCouponType(),
+        notification.getCoupon() == null ? null :
+            notification.getCoupon().getCouponInfo().getName(),
+        notification.getCoupon() == null ? null :
+            notification.getCoupon().getCouponInfo().getExpireDate()
+    );
+  }
 
 }

--- a/src/main/java/yapp/buddycon/web/notification/adapter/out/NotificationQueryRepository.java
+++ b/src/main/java/yapp/buddycon/web/notification/adapter/out/NotificationQueryRepository.java
@@ -1,0 +1,21 @@
+package yapp.buddycon.web.notification.adapter.out;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import yapp.buddycon.common.exception.CustomException;
+import yapp.buddycon.common.exception.ErrorCode;
+import yapp.buddycon.web.notification.application.port.out.NotificationQueryPort;
+import yapp.buddycon.web.notification.domain.Notification;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationQueryRepository implements NotificationQueryPort {
+
+  private final NotificationJpaRepository notificationJpaRepository;
+
+  @Override
+  public Notification findNotificationById(Long notificationId) {
+    return notificationJpaRepository.findById(notificationId)
+        .orElseThrow(() -> new CustomException(ErrorCode.INVALID_NOTIFICATION_ID));
+  }
+}

--- a/src/main/java/yapp/buddycon/web/notification/application/port/in/NotificationUseCase.java
+++ b/src/main/java/yapp/buddycon/web/notification/application/port/in/NotificationUseCase.java
@@ -1,0 +1,9 @@
+package yapp.buddycon.web.notification.application.port.in;
+
+import yapp.buddycon.web.notification.adapter.in.response.NotificationResponseDto;
+
+public interface NotificationUseCase {
+
+  NotificationResponseDto getNotification(Long memberId, Long notificationId);
+
+}

--- a/src/main/java/yapp/buddycon/web/notification/application/port/out/NotificationQueryPort.java
+++ b/src/main/java/yapp/buddycon/web/notification/application/port/out/NotificationQueryPort.java
@@ -1,0 +1,9 @@
+package yapp.buddycon.web.notification.application.port.out;
+
+import yapp.buddycon.web.notification.domain.Notification;
+
+public interface NotificationQueryPort {
+
+  Notification findNotificationById(Long notificationId);
+
+}

--- a/src/main/java/yapp/buddycon/web/notification/application/service/NotificationService.java
+++ b/src/main/java/yapp/buddycon/web/notification/application/service/NotificationService.java
@@ -1,0 +1,26 @@
+package yapp.buddycon.web.notification.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import yapp.buddycon.common.exception.CustomException;
+import yapp.buddycon.common.exception.ErrorCode;
+import yapp.buddycon.web.notification.adapter.in.response.NotificationResponseDto;
+import yapp.buddycon.web.notification.application.port.in.NotificationUseCase;
+import yapp.buddycon.web.notification.application.port.out.NotificationQueryPort;
+import yapp.buddycon.web.notification.domain.Notification;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService implements NotificationUseCase {
+
+  private final NotificationQueryPort notificationQueryPort;
+
+  @Override
+  public NotificationResponseDto getNotification(Long memberId, Long notificationId) {
+    Notification notification = notificationQueryPort.findNotificationById(notificationId);
+    if (!notification.checkAuth(memberId)) {
+      throw new CustomException(ErrorCode.CANT_ACCESS_NOTIFICATION);
+    }
+    return NotificationResponseDto.valueOf(notification);
+  }
+}

--- a/src/main/java/yapp/buddycon/web/notification/domain/Notification.java
+++ b/src/main/java/yapp/buddycon/web/notification/domain/Notification.java
@@ -5,12 +5,14 @@ import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import yapp.buddycon.common.domain.BaseEntity;
 import yapp.buddycon.web.coupon.domain.Coupon;
 import yapp.buddycon.web.member.domain.Member;
 
 @Entity
+@Getter
 @AllArgsConstructor
 @NoArgsConstructor
 public class Notification extends BaseEntity {
@@ -31,4 +33,11 @@ public class Notification extends BaseEntity {
   @JoinColumn(name = "coupon_id")
   private Coupon coupon;
 
+  public boolean checkAuth(long memberId) {
+    // 공지사항인 경우 member = null
+    if (member != null) {
+      return member.getId() == memberId;
+    }
+    return true;
+  }
 }


### PR DESCRIPTION
## 개요

알림 상세 조회 API 추가

## 작업 내용

- 알림이나 공지사항 내용을 상세 조회하는 api를 구현했습니다.
- 공지사항의 경우 member와 coupon이 null이기 때문에 알림 id만 받고, 권한을 확인하는 방식을 사용했습니다.
  - 공지사항 : `member == null, coupon == null`
  - 알림 : `member != null, coupon != null`

## 메모

- JPQL을 쓰지 않는 방법을 사용해 봤습니다. 의견 부탁드립니다! (JPQL 쓰는게 더 깔끔한 것 같기도 합니다 흠흠,,)

