### PR TITLE
[Issue #37] 바코드로 쿠폰 정보 불러오기 api

### DIFF
--- a/src/main/java/yapp/buddycon/common/exception/ErrorCode.java
+++ b/src/main/java/yapp/buddycon/common/exception/ErrorCode.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
 
 @Getter
 @AllArgsConstructor
@@ -29,6 +30,8 @@ public enum ErrorCode {
 
   /* 403 FORBIDDEN */
   CANT_ACCESS_NOTIFICATION(FORBIDDEN, "해당 알림에 대한 권한이 없습니다."),
+
+  NOT_EXIST_BARCODE_NUMBER(NO_CONTENT, "바코드에 해당하는 쿠폰이 존재하지 않습니다"),
 
   ;
 

--- a/src/main/java/yapp/buddycon/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/yapp/buddycon/common/exception/GlobalExceptionHandler.java
@@ -1,10 +1,13 @@
 package yapp.buddycon.common.exception;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import javax.persistence.PersistenceException;
 
 @Slf4j
 @RestControllerAdvice
@@ -15,4 +18,14 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     log.error("handleCustomException throw CustomException : {}", e.getErrorCode());
     return ErrorResponse.toResponseEntity(e.getErrorCode());
   }
+
+  @ExceptionHandler(value = { PersistenceException.class })
+  protected ResponseEntity<ErrorResponse> handlePersistenceException(PersistenceException e) {
+    log.error("handlePersistenceException throw PersistenceException : {}", e.getMessage());
+    final ErrorResponse errorResponse = ErrorResponse.builder()
+      .code("DatabaseException")
+      .message("database error").build();
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+  }
 }
+

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/in/CouponController.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/in/CouponController.java
@@ -8,9 +8,7 @@ import org.springframework.web.multipart.MultipartFile;
 import yapp.buddycon.common.response.DefaultResponseDto;
 import yapp.buddycon.web.auth.adapter.out.AuthMember;
 import yapp.buddycon.web.coupon.adapter.in.request.*;
-import yapp.buddycon.web.coupon.adapter.in.response.CouponsResponseDto;
-import yapp.buddycon.web.coupon.adapter.in.response.CustomCouponInfoResponseDto;
-import yapp.buddycon.web.coupon.adapter.in.response.GifticonInfoResponseDto;
+import yapp.buddycon.web.coupon.adapter.in.response.*;
 import yapp.buddycon.web.coupon.application.port.in.CouponUseCase;
 
 import java.util.List;
@@ -66,14 +64,14 @@ public class CouponController {
 
   @GetMapping("/gifticon/info")
   @Operation(summary = "바코드로 기프티콘 정보 불러오기")
-  public GifticonInfoResponseDto getGifticonInfoByBarcode(@RequestParam("barcode") String barcode, AuthMember authMember) {
-    return null;
+  public SharedGifticonInfoResponseDto getGifticonInfoByBarcode(@RequestParam("barcode") String barcode, AuthMember authMember) {
+    return couponUseCase.getSharedGifticonInfoFromBarcode(barcode);
   }
 
   @GetMapping("/custom-coupon/info")
   @Operation(summary = "바코드로 제작티콘 정보 불러오기")
-  public CustomCouponInfoResponseDto getCustomCouponInfoByBarcode(@RequestParam("barcode") String barcode, AuthMember authMember) {
-    return null;
+  public SharedCustomCouponResponseDto getCustomCouponInfoByBarcode(@RequestParam("barcode") String barcode, AuthMember authMember) {
+    return couponUseCase.getSharedCustomCouponInfoFromBarcode(barcode);
   }
 
   @DeleteMapping("/{id}")

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/in/response/SharedCustomCouponResponseDto.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/in/response/SharedCustomCouponResponseDto.java
@@ -1,0 +1,15 @@
+package yapp.buddycon.web.coupon.adapter.in.response;
+
+import java.time.LocalDate;
+
+public record SharedCustomCouponResponseDto(
+  Long id,
+  String imageUrl,
+  String barcode,
+  String name,
+  LocalDate expireDate,
+  String storeName,
+  String sentMemberName,
+  String memo
+) {
+}

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/in/response/SharedGifticonInfoResponseDto.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/in/response/SharedGifticonInfoResponseDto.java
@@ -1,0 +1,14 @@
+package yapp.buddycon.web.coupon.adapter.in.response;
+
+import java.time.LocalDate;
+
+public record SharedGifticonInfoResponseDto(
+  Long id,
+  String imageUrl,
+  String barcode,
+  String name,
+  LocalDate expireDate,
+  String storeName,
+  String memo
+) {
+}

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/out/SharedCouponJpaRepository.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/out/SharedCouponJpaRepository.java
@@ -1,7 +1,29 @@
 package yapp.buddycon.web.coupon.adapter.out;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import yapp.buddycon.web.coupon.adapter.in.response.SharedCustomCouponResponseDto;
+import yapp.buddycon.web.coupon.adapter.in.response.SharedGifticonInfoResponseDto;
 import yapp.buddycon.web.coupon.domain.SharedCoupon;
 
+import java.util.Optional;
+
 public interface SharedCouponJpaRepository extends JpaRepository<SharedCoupon, Long> {
+  @Query(value = """
+    select new yapp.buddycon.web.coupon.adapter.in.response.SharedGifticonInfoResponseDto(s.id, s.sharedCouponInfo.imageUrl, s.sharedCouponInfo.barcode, s.sharedCouponInfo.name, s.sharedCouponInfo.expireDate, s.sharedCouponInfo.storeName, s.sharedCouponInfo.memo)
+    from SharedCoupon s
+    where s.sharedCouponInfo.barcode = :barcode
+    and s.coupon.couponType = 'REAL'
+    and s.shared = false
+  """)
+  Optional<SharedGifticonInfoResponseDto> findSharedGifticonByBarcode(String barcode);
+
+  @Query(value = """
+    select new yapp.buddycon.web.coupon.adapter.in.response.SharedCustomCouponResponseDto(s.id, s.sharedCouponInfo.imageUrl, s.sharedCouponInfo.barcode, s.sharedCouponInfo.name, s.sharedCouponInfo.expireDate, s.sharedCouponInfo.storeName, s.sharedCouponInfo.sentMember.name, s.sharedCouponInfo.memo)
+    from SharedCoupon s
+    where s.sharedCouponInfo.barcode = :barcode
+    and s.coupon.couponType = 'CUSTOM'
+    and s.shared = false
+  """)
+  Optional<SharedCustomCouponResponseDto> findSharedCustomCouponByBarcode(String barcode);
 }

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/out/SharedCouponQueryRepository.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/out/SharedCouponQueryRepository.java
@@ -2,11 +2,26 @@ package yapp.buddycon.web.coupon.adapter.out;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import yapp.buddycon.common.exception.CustomException;
+import yapp.buddycon.common.exception.ErrorCode;
+import yapp.buddycon.web.coupon.adapter.in.response.SharedCustomCouponResponseDto;
+import yapp.buddycon.web.coupon.adapter.in.response.SharedGifticonInfoResponseDto;
+import yapp.buddycon.web.coupon.application.port.out.CouponToSharedCouponQueryPort;
 import yapp.buddycon.web.coupon.application.port.out.SharedCouponQueryPort;
 
 @Repository
 @RequiredArgsConstructor
-public class SharedCouponQueryRepository implements SharedCouponQueryPort {
+public class SharedCouponQueryRepository implements SharedCouponQueryPort, CouponToSharedCouponQueryPort {
 
   private final SharedCouponJpaRepository sharedCouponJpaRepository;
+
+  @Override
+  public SharedGifticonInfoResponseDto findSharedGifticonByBarcode(String barcode) {
+    return sharedCouponJpaRepository.findSharedGifticonByBarcode(barcode).orElseThrow(() -> new CustomException(ErrorCode.NOT_EXIST_BARCODE_NUMBER));
+  }
+
+  @Override
+  public SharedCustomCouponResponseDto findSharedCustomCouponByBarcode(String barcode) {
+    return sharedCouponJpaRepository.findSharedCustomCouponByBarcode(barcode).orElseThrow(() -> new CustomException(ErrorCode.NOT_EXIST_BARCODE_NUMBER));
+  }
 }

--- a/src/main/java/yapp/buddycon/web/coupon/application/port/in/CouponUseCase.java
+++ b/src/main/java/yapp/buddycon/web/coupon/application/port/in/CouponUseCase.java
@@ -3,7 +3,7 @@ package yapp.buddycon.web.coupon.application.port.in;
 import org.springframework.data.domain.Pageable;
 import yapp.buddycon.common.response.DefaultResponseDto;
 import yapp.buddycon.web.auth.adapter.out.AuthMember;
-import yapp.buddycon.web.coupon.adapter.in.response.CouponsResponseDto;
+import yapp.buddycon.web.coupon.adapter.in.response.*;
 
 import java.util.List;
 
@@ -13,13 +13,13 @@ import yapp.buddycon.web.coupon.adapter.in.response.GifticonInfoResponseDto;
 public interface CouponUseCase {
 
   List<CouponsResponseDto> getSortedGifticons(boolean usable, Pageable pageable, AuthMember authMember);
-
   List<CouponsResponseDto> getSortedCustomCoupons(boolean usable, Pageable pageable, AuthMember authMember);
 
-
   GifticonInfoResponseDto getGifticonInfo(Long memberId, Long couponId);
-
   CustomCouponInfoResponseDto getCustomCouponInfo(Long memberId, Long couponId);
 
   DefaultResponseDto deleteCoupon(Long memberId, Long couponId);
+
+  SharedGifticonInfoResponseDto getSharedGifticonInfoFromBarcode(String barcode);
+  SharedCustomCouponResponseDto getSharedCustomCouponInfoFromBarcode(String barcode);
 }

--- a/src/main/java/yapp/buddycon/web/coupon/application/port/out/CouponToSharedCouponQueryPort.java
+++ b/src/main/java/yapp/buddycon/web/coupon/application/port/out/CouponToSharedCouponQueryPort.java
@@ -1,0 +1,10 @@
+package yapp.buddycon.web.coupon.application.port.out;
+
+import yapp.buddycon.web.coupon.adapter.in.response.SharedCustomCouponResponseDto;
+import yapp.buddycon.web.coupon.adapter.in.response.SharedGifticonInfoResponseDto;
+
+public interface CouponToSharedCouponQueryPort {
+
+  SharedGifticonInfoResponseDto findSharedGifticonByBarcode(String barcode);
+  SharedCustomCouponResponseDto findSharedCustomCouponByBarcode(String barcode);
+}

--- a/src/main/java/yapp/buddycon/web/coupon/application/service/CouponService.java
+++ b/src/main/java/yapp/buddycon/web/coupon/application/service/CouponService.java
@@ -8,13 +8,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import yapp.buddycon.common.response.DefaultResponseDto;
 import yapp.buddycon.web.auth.adapter.out.AuthMember;
-import yapp.buddycon.web.coupon.adapter.in.response.CouponsResponseDto;
-import yapp.buddycon.web.coupon.adapter.in.response.CustomCouponInfoResponseDto;
-import yapp.buddycon.web.coupon.adapter.in.response.GifticonInfoResponseDto;
+import yapp.buddycon.web.coupon.adapter.in.response.*;
 import yapp.buddycon.web.coupon.application.port.in.CouponUseCase;
 import yapp.buddycon.web.coupon.application.port.out.CouponCommandPort;
 import yapp.buddycon.web.coupon.application.port.out.CouponQueryPort;
 import yapp.buddycon.web.coupon.domain.Coupon;
+import yapp.buddycon.web.coupon.application.port.out.CouponToSharedCouponQueryPort;
 
 import java.util.List;
 
@@ -24,6 +23,7 @@ public class CouponService implements CouponUseCase {
 
   private final CouponCommandPort couponCommandPort;
   private final CouponQueryPort couponQueryPort;
+  private final CouponToSharedCouponQueryPort couponToSharedCouponQueryPort;
 
   @Override
   public List<CouponsResponseDto> getSortedGifticons(boolean usable, Pageable pageable, AuthMember authMember) {
@@ -57,5 +57,15 @@ public class CouponService implements CouponUseCase {
     Coupon coupon = couponQueryPort.findById(couponId);
     couponCommandPort.deleteCoupon(memberId, coupon.getId());
     return new DefaultResponseDto(true, "쿠폰을 삭제하였습니다.");
+  }
+
+  @Override
+  public SharedGifticonInfoResponseDto getSharedGifticonInfoFromBarcode(String barcode) {
+    return couponToSharedCouponQueryPort.findSharedGifticonByBarcode(barcode);
+  }
+
+  @Override
+  public SharedCustomCouponResponseDto getSharedCustomCouponInfoFromBarcode(String barcode) {
+    return couponToSharedCouponQueryPort.findSharedCustomCouponByBarcode(barcode);
   }
 }

--- a/src/main/java/yapp/buddycon/web/coupon/domain/SharedCouponInfo.java
+++ b/src/main/java/yapp/buddycon/web/coupon/domain/SharedCouponInfo.java
@@ -1,8 +1,12 @@
 package yapp.buddycon.web.coupon.domain;
 
 
+import yapp.buddycon.web.member.domain.Member;
+
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -15,8 +19,9 @@ public class SharedCouponInfo {
   @Column(name = "image_url", nullable = false)
   private String imageUrl;
 
-  @Column(name = "sent_member_id", nullable = false)
-  private long sentMemberId;
+  @OneToOne
+  @JoinColumn(name = "member_id", nullable = false)
+  private Member sentMember;
 
   @Column(name = "name", nullable = false, length = 16)
   private String name;


### PR DESCRIPTION
## 개요
바코드로 쿠폰 정보 불러오기 api

## 작업 내용
- ShareCouponInfo 클래스 내에 memberId가 OneToOne 으로 매핑 되어있지 않았어서, 리팩토링하였습니다.
- global handler에 메소드를 추가하였습니다 (현희님 어떻게 생각하실지 궁금합니다..)
  - 바코드를 불러올때 해당하는 SharedCoupon의 튜플이 두개 이상이라면 'query did not return a unique result: 2' Exception이 발생하였습니다.
  - 제가 생각한 해결방안은 아래와 같았습니다
    1. List로 받아와서 그 중 하나를 선택하거나
    2. query에 limit 1을 걸거나
    3. internal server error로 exception을 냄
  - 제가 생각했을 때, 1번과 2번은 사용자에게 잘못된 쿠폰정보가 내려갈 수도 있을 것같아서, 3번을 선택했습니다.
  - 3번을 택한 대신, 프론트 분들께 대략적으로 어떤 exception인지 전달드려야 할 것같아, PersistenceException을 Handling하도록 메소드를 추가하였습니다.
  - 대신 너무 자세한 서버의 상황은 노출되지 않도록, database exception이라는 메시지를 전달드리는 것으로 구현하였습니다.
- 바코드로 쿠폰 정보 불러오기 api를 구현하였습니다!

## 메모

close #37 
