### PR TITLE
[Issue #42] 만든 쿠폰 정렬 조회 api

### DIFF
--- a/src/main/java/yapp/buddycon/web/coupon/adapter/in/SharedCouponController.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/in/SharedCouponController.java
@@ -21,19 +21,19 @@ public class SharedCouponController {
 
   @GetMapping("")
   @Operation(summary = "만든쿠폰 정렬 조회")
-  public List<SharedCouponsResponseDto> getSortedSharedCoupons(Pageable pageable) {
-    return null;
+  public List<SharedCouponsResponseDto> getSortedSharedCoupons(@RequestParam("unshared") boolean unshared, Pageable pageable, AuthMember authMember) {
+    return sharedCouponUseCase.getSortedSharedCoupons(unshared, pageable, authMember.id());
   }
 
   @PatchMapping("/{id}/state")
   @Operation(summary = "제작티콘 선물 후 공유완료 상태로 변경", description = "카카오톡으로 메시지를 보내기를 성공한 경우 api")
-  public DefaultResponseDto changeCustomCouponState(@PathVariable("id") long id) {
+  public DefaultResponseDto changeCustomCouponState(@PathVariable("id") long id, AuthMember authMember) {
     return null;
   }
 
   @DeleteMapping("/{id}")
   @Operation(summary = "만든쿠폰 삭제")
-  public DefaultResponseDto deleteSharedCoupon(@PathVariable("id") long id) {
+  public DefaultResponseDto deleteSharedCoupon(@PathVariable("id") long id, AuthMember authMember) {
     return null;
   }
 }

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/in/response/SharedCouponsResponseDto.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/in/response/SharedCouponsResponseDto.java
@@ -4,7 +4,7 @@ import java.time.LocalDate;
 
 public record SharedCouponsResponseDto(
   Long id,
-  String path,
+  String imageUrl,
   String name,
   LocalDate expireDate,
   boolean shared

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/out/SharedCouponJpaRepository.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/out/SharedCouponJpaRepository.java
@@ -1,11 +1,14 @@
 package yapp.buddycon.web.coupon.adapter.out;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import yapp.buddycon.web.coupon.adapter.in.response.SharedCouponsResponseDto;
 import yapp.buddycon.web.coupon.adapter.in.response.SharedCustomCouponResponseDto;
 import yapp.buddycon.web.coupon.adapter.in.response.SharedGifticonInfoResponseDto;
 import yapp.buddycon.web.coupon.domain.SharedCoupon;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface SharedCouponJpaRepository extends JpaRepository<SharedCoupon, Long> {
@@ -26,4 +29,20 @@ public interface SharedCouponJpaRepository extends JpaRepository<SharedCoupon, L
     and s.shared = false
   """)
   Optional<SharedCustomCouponResponseDto> findSharedCustomCouponByBarcode(String barcode);
+
+
+  @Query(value = """
+    select new yapp.buddycon.web.coupon.adapter.in.response.SharedCouponsResponseDto(s.id, s.sharedCouponInfo.imageUrl, s.sharedCouponInfo.name, s.sharedCouponInfo.expireDate, s.shared)
+    from SharedCoupon s
+    where s.sharedCouponInfo.sentMember.id = :memberId
+    order by s.shared
+  """)
+  List<SharedCouponsResponseDto> findUnsharedCustomCouponsSortedBy(Long memberId, Pageable pageable);
+
+  @Query(value = """
+    select new yapp.buddycon.web.coupon.adapter.in.response.SharedCouponsResponseDto(s.id, s.sharedCouponInfo.imageUrl, s.sharedCouponInfo.name, s.sharedCouponInfo.expireDate, s.shared)
+    from SharedCoupon s
+    where s.sharedCouponInfo.sentMember.id = :memberId
+  """)
+  List<SharedCouponsResponseDto> findCustomCouponsSortedBy(Long memberId, Pageable pageable);
 }

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/out/SharedCouponQueryRepository.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/out/SharedCouponQueryRepository.java
@@ -1,13 +1,17 @@
 package yapp.buddycon.web.coupon.adapter.out;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import yapp.buddycon.common.exception.CustomException;
 import yapp.buddycon.common.exception.ErrorCode;
+import yapp.buddycon.web.coupon.adapter.in.response.SharedCouponsResponseDto;
 import yapp.buddycon.web.coupon.adapter.in.response.SharedCustomCouponResponseDto;
 import yapp.buddycon.web.coupon.adapter.in.response.SharedGifticonInfoResponseDto;
 import yapp.buddycon.web.coupon.application.port.out.CouponToSharedCouponQueryPort;
 import yapp.buddycon.web.coupon.application.port.out.SharedCouponQueryPort;
+
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
@@ -23,5 +27,15 @@ public class SharedCouponQueryRepository implements SharedCouponQueryPort, Coupo
   @Override
   public SharedCustomCouponResponseDto findSharedCustomCouponByBarcode(String barcode) {
     return sharedCouponJpaRepository.findSharedCustomCouponByBarcode(barcode).orElseThrow(() -> new CustomException(ErrorCode.NOT_EXIST_BARCODE_NUMBER));
+  }
+
+  @Override
+  public List<SharedCouponsResponseDto> findUnsharedCustomCouponsSortedBy(Long memberId, Pageable pageable) {
+    return sharedCouponJpaRepository.findUnsharedCustomCouponsSortedBy(memberId, pageable);
+  }
+
+  @Override
+  public List<SharedCouponsResponseDto> findCustomCouponsSortedBy(Long memberId, Pageable pageable) {
+    return sharedCouponJpaRepository.findCustomCouponsSortedBy(memberId, pageable);
   }
 }

--- a/src/main/java/yapp/buddycon/web/coupon/application/port/in/SharedCouponUseCase.java
+++ b/src/main/java/yapp/buddycon/web/coupon/application/port/in/SharedCouponUseCase.java
@@ -1,4 +1,10 @@
 package yapp.buddycon.web.coupon.application.port.in;
 
+import org.springframework.data.domain.Pageable;
+import yapp.buddycon.web.coupon.adapter.in.response.SharedCouponsResponseDto;
+
+import java.util.List;
+
 public interface SharedCouponUseCase {
+  List<SharedCouponsResponseDto> getSortedSharedCoupons(boolean unshared, Pageable pageable, Long memberId);
 }

--- a/src/main/java/yapp/buddycon/web/coupon/application/port/out/SharedCouponQueryPort.java
+++ b/src/main/java/yapp/buddycon/web/coupon/application/port/out/SharedCouponQueryPort.java
@@ -1,4 +1,12 @@
 package yapp.buddycon.web.coupon.application.port.out;
 
+import org.springframework.data.domain.Pageable;
+import yapp.buddycon.web.coupon.adapter.in.response.SharedCouponsResponseDto;
+
+import java.util.List;
+
 public interface SharedCouponQueryPort {
+
+  List<SharedCouponsResponseDto> findUnsharedCustomCouponsSortedBy(Long memberId, Pageable pageable);
+  List<SharedCouponsResponseDto> findCustomCouponsSortedBy(Long memberId, Pageable pageable);
 }

--- a/src/main/java/yapp/buddycon/web/coupon/application/service/SharedCouponService.java
+++ b/src/main/java/yapp/buddycon/web/coupon/application/service/SharedCouponService.java
@@ -1,10 +1,16 @@
 package yapp.buddycon.web.coupon.application.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import yapp.buddycon.web.coupon.adapter.in.response.SharedCouponsResponseDto;
 import yapp.buddycon.web.coupon.application.port.in.SharedCouponUseCase;
 import yapp.buddycon.web.coupon.application.port.out.SharedCouponCommandPort;
 import yapp.buddycon.web.coupon.application.port.out.SharedCouponQueryPort;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -12,4 +18,12 @@ public class SharedCouponService implements SharedCouponUseCase {
 
   private final SharedCouponCommandPort sharedCouponCommandPort;
   private final SharedCouponQueryPort sharedCouponQueryPort;
+
+  @Override
+  public List<SharedCouponsResponseDto> getSortedSharedCoupons(boolean unshared, Pageable pageable, Long memberId) {
+    Sort sort = SortPageableValidation.validateSortProperty(pageable.getSort().toString());
+    PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
+    if(unshared) return sharedCouponQueryPort.findUnsharedCustomCouponsSortedBy(memberId, pageRequest);
+    else return sharedCouponQueryPort.findCustomCouponsSortedBy(memberId, pageRequest);
+  }
 }

--- a/src/main/java/yapp/buddycon/web/coupon/application/service/SortPageableValidation.java
+++ b/src/main/java/yapp/buddycon/web/coupon/application/service/SortPageableValidation.java
@@ -7,6 +7,7 @@ import yapp.buddycon.common.exception.ErrorCode;
 import java.util.Arrays;
 
 public enum SortPageableValidation {
+  UNSHARED_ASC_SORT("createdAt: DESC", Sort.by("createdAt").descending()),
   CREATED_AT_ASC_SORT("createdAt: ASC", Sort.by("createdAt").ascending()),
   EXPIRE_DATE_ASC_SORT("expireDate: ASC", Sort.by("couponInfo.expireDate").ascending()),
   NAME_ASC_SORT("name: ASC", Sort.by("couponInfo.name").ascending());


### PR DESCRIPTION
## 개요
만든 쿠폰 정렬 조회 api 구현

## 작업 내용
만든 쿠폰 정렬 조회 api 구현 완료
<img width="400" alt="스크린샷 2023-02-02 오후 2 08 05" src="https://user-images.githubusercontent.com/69676101/216236736-02c54dc6-b91c-46a4-9187-e678aec3d71f.png">

## 메모
- 만든 쿠폰 정렬 조회
  - request로 unshared(boolean), pageable(Pageable)을 받아옴
  - 미공유순인경우 (unshared == true)
    ```java   
    @Query(value = """
    select new yapp.buddycon.web.coupon.adapter.in.response.SharedCouponsResponseDto(s.id, s.sharedCouponInfo.imageUrl, s.sharedCouponInfo.name, s.sharedCouponInfo.expireDate, s.shared)
    from SharedCoupon s
    where s.sharedCouponInfo.sentMember.id = :memberId
    order by s.shared
    """)
    List<SharedCouponsResponseDto> findUnsharedCustomCouponsSortedBy(Long memberId, Pageable pageable);
    ```
    - shared로 order후 createdAt 내림차순 정렬하는 쿼리
  - 유효일자순,만든순,이름순의 경우 (unshared == false)
    - pageable을 토대로 정렬

close #42 
