### PR TITLE
[Issue #16] 알림 목록 조회 및 확인 완료 처리 API

### DIFF
--- a/src/main/java/yapp/buddycon/common/PagingDto.java
+++ b/src/main/java/yapp/buddycon/common/PagingDto.java
@@ -1,0 +1,20 @@
+package yapp.buddycon.common;
+
+import yapp.buddycon.common.exception.CustomException;
+import yapp.buddycon.common.exception.ErrorCode;
+
+public record PagingDto(
+    int page,
+    int size
+) {
+
+  public void checkValidation() {
+    if (page < 0) {
+      throw new CustomException(ErrorCode.INVALID_PAGE);
+    }
+    if (size <= 0 || size > 1000) {
+      throw new CustomException(ErrorCode.INVALID_SIZE);
+    }
+  }
+
+}

--- a/src/main/java/yapp/buddycon/common/exception/ErrorCode.java
+++ b/src/main/java/yapp/buddycon/common/exception/ErrorCode.java
@@ -28,6 +28,9 @@ public enum ErrorCode {
   INVALID_COUPON_ID(BAD_REQUEST, "해당 쿠폰 id가 존재하지 않습니다."),
   INVALID_NOTIFICATION_ID(BAD_REQUEST, "해당 알림 id가 존재하지 않습니다."),
 
+  INVALID_PAGE(BAD_REQUEST, "올바르지 않은 page 입니다."),
+  INVALID_SIZE(BAD_REQUEST, "올바르지 않은 size 입니다."),
+
   /* 403 FORBIDDEN */
   CANT_ACCESS_NOTIFICATION(FORBIDDEN, "해당 알림에 대한 권한이 없습니다."),
 

--- a/src/main/java/yapp/buddycon/web/notification/adapter/in/NotificationController.java
+++ b/src/main/java/yapp/buddycon/web/notification/adapter/in/NotificationController.java
@@ -3,11 +3,11 @@ package yapp.buddycon.web.notification.adapter.in;
 import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import yapp.buddycon.common.PagingDto;
 import yapp.buddycon.web.auth.adapter.out.AuthMember;
 import yapp.buddycon.web.notification.adapter.in.response.NotificationResponseDto;
 import yapp.buddycon.web.notification.application.port.in.NotificationUseCase;
@@ -21,9 +21,8 @@ public class NotificationController {
 
   @GetMapping("")
   @Operation(summary = "알림 정렬 조회", description = "알림 목록 조회 및 확인 완료 처리")
-  public List<NotificationResponseDto> getNotifications(AuthMember authMember,
-      Pageable pageable) {
-    List<NotificationResponseDto> result = null;
+  public List<NotificationResponseDto> getSortedNotifications(AuthMember authMember, PagingDto pagingDto) {
+    List<NotificationResponseDto> result = notificationUseCase.getSortedNotifications(authMember.id(), pagingDto);
     return result;
   }
 

--- a/src/main/java/yapp/buddycon/web/notification/adapter/out/NotificationJpaRepository.java
+++ b/src/main/java/yapp/buddycon/web/notification/adapter/out/NotificationJpaRepository.java
@@ -1,8 +1,12 @@
 package yapp.buddycon.web.notification.adapter.out;
 
+import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import yapp.buddycon.web.notification.domain.Notification;
 
 public interface NotificationJpaRepository extends JpaRepository<Notification, Long> {
+
+  List<Notification> findAllByMemberIdOrderByCreatedAtDesc(long memberId, Pageable pageable);
 
 }

--- a/src/main/java/yapp/buddycon/web/notification/adapter/out/NotificationQueryRepository.java
+++ b/src/main/java/yapp/buddycon/web/notification/adapter/out/NotificationQueryRepository.java
@@ -1,6 +1,8 @@
 package yapp.buddycon.web.notification.adapter.out;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import yapp.buddycon.common.exception.CustomException;
 import yapp.buddycon.common.exception.ErrorCode;
@@ -12,6 +14,11 @@ import yapp.buddycon.web.notification.domain.Notification;
 public class NotificationQueryRepository implements NotificationQueryPort {
 
   private final NotificationJpaRepository notificationJpaRepository;
+
+  @Override
+  public List<Notification> findAllByMemberIdAndOrderByCreatedAt(long memberId, Pageable pageable) {
+    return notificationJpaRepository.findAllByMemberIdOrderByCreatedAtDesc(memberId, pageable);
+  }
 
   @Override
   public Notification findNotificationById(Long notificationId) {

--- a/src/main/java/yapp/buddycon/web/notification/application/port/in/NotificationUseCase.java
+++ b/src/main/java/yapp/buddycon/web/notification/application/port/in/NotificationUseCase.java
@@ -1,8 +1,12 @@
 package yapp.buddycon.web.notification.application.port.in;
 
+import java.util.List;
+import yapp.buddycon.common.PagingDto;
 import yapp.buddycon.web.notification.adapter.in.response.NotificationResponseDto;
 
 public interface NotificationUseCase {
+
+  List<NotificationResponseDto> getSortedNotifications(Long memberId, PagingDto pagingDto);
 
   NotificationResponseDto getNotification(Long memberId, Long notificationId);
 

--- a/src/main/java/yapp/buddycon/web/notification/application/port/out/NotificationQueryPort.java
+++ b/src/main/java/yapp/buddycon/web/notification/application/port/out/NotificationQueryPort.java
@@ -1,8 +1,12 @@
 package yapp.buddycon.web.notification.application.port.out;
 
+import java.util.List;
+import org.springframework.data.domain.Pageable;
 import yapp.buddycon.web.notification.domain.Notification;
 
 public interface NotificationQueryPort {
+
+  List<Notification> findAllByMemberIdAndOrderByCreatedAt(long memberId, Pageable pageable);
 
   Notification findNotificationById(Long notificationId);
 

--- a/src/main/java/yapp/buddycon/web/notification/application/service/NotificationService.java
+++ b/src/main/java/yapp/buddycon/web/notification/application/service/NotificationService.java
@@ -1,7 +1,12 @@
 package yapp.buddycon.web.notification.application.service;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import yapp.buddycon.common.PagingDto;
 import yapp.buddycon.common.exception.CustomException;
 import yapp.buddycon.common.exception.ErrorCode;
 import yapp.buddycon.web.notification.adapter.in.response.NotificationResponseDto;
@@ -14,6 +19,19 @@ import yapp.buddycon.web.notification.domain.Notification;
 public class NotificationService implements NotificationUseCase {
 
   private final NotificationQueryPort notificationQueryPort;
+
+  @Transactional
+  @Override
+  public List<NotificationResponseDto> getSortedNotifications(Long memberId, PagingDto pagingDto) {
+    pagingDto.checkValidation();
+    PageRequest pageRequest = PageRequest.of(pagingDto.page(), pagingDto.size());
+    List<Notification> notificationList = notificationQueryPort.findAllByMemberIdAndOrderByCreatedAt(memberId, pageRequest);
+
+    for (Notification notification : notificationList) {
+      notification.setCheckedTrue();
+    }
+    return notificationList.stream().map(NotificationResponseDto::valueOf).collect(Collectors.toList());
+  }
 
   @Override
   public NotificationResponseDto getNotification(Long memberId, Long notificationId) {

--- a/src/main/java/yapp/buddycon/web/notification/domain/Notification.java
+++ b/src/main/java/yapp/buddycon/web/notification/domain/Notification.java
@@ -26,18 +26,14 @@ public class Notification extends BaseEntity {
   private boolean checked;
 
   @ManyToOne
-  @JoinColumn(name = "member_id")
+  @JoinColumn(name = "member_id", nullable = false)
   private Member member;
 
   @ManyToOne
   @JoinColumn(name = "coupon_id")
-  private Coupon coupon;
+  private Coupon coupon;  // null이면 공지사항
 
   public boolean checkAuth(long memberId) {
-    // 공지사항인 경우 member = null
-    if (member != null) {
-      return member.getId() == memberId;
-    }
-    return true;
+    return member.getId() == memberId;
   }
 }

--- a/src/main/java/yapp/buddycon/web/notification/domain/Notification.java
+++ b/src/main/java/yapp/buddycon/web/notification/domain/Notification.java
@@ -36,4 +36,8 @@ public class Notification extends BaseEntity {
   public boolean checkAuth(long memberId) {
     return member.getId() == memberId;
   }
+
+  public void setCheckedTrue() {
+    this.checked = true;
+  }
 }


### PR DESCRIPTION
## 개요

알림 목록 조회 및 확인 완료 처리 API 추가

## 작업 내용

- PagingDto 추가
- `GET::/api/v1/notifications` API 추가

## 메모

- 공지사항도 member 별로 각각 따로 가져야 할 것 같아서 엔티티를 변경하였습니다. 우선 가장 간단하게 구현하려 하는데요. 공지하기 API를 만들어서 각 유저별로 해당 공지사항을 전부 추가하는 방식을 고려하고 있습니다.

close #16 
