### PR TITLE
[Issue #48] 알림 설정 조회 API

### DIFF
--- a/src/main/java/yapp/buddycon/common/exception/ErrorCode.java
+++ b/src/main/java/yapp/buddycon/common/exception/ErrorCode.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 
 @Getter
@@ -25,8 +26,9 @@ public enum ErrorCode {
 
   INVALID_SORT_PROPERTY(BAD_REQUEST, "잘못된 sort 방식입니다."),
 
-  INVALID_COUPON_ID(BAD_REQUEST, "해당 쿠폰 id가 존재하지 않습니다."),
-  INVALID_NOTIFICATION_ID(BAD_REQUEST, "해당 알림 id가 존재하지 않습니다."),
+  INVALID_COUPON_ID(NOT_FOUND, "해당 쿠폰 id가 존재하지 않습니다."),
+  INVALID_NOTIFICATION_ID(NOT_FOUND, "해당 알림 id가 존재하지 않습니다."),
+  NOTIFICATION_SETTING_NOT_FOUND(NOT_FOUND, "해당 알림 설정이 존재하지 않습니다."),
 
   /* 403 FORBIDDEN */
   CANT_ACCESS_NOTIFICATION(FORBIDDEN, "해당 알림에 대한 권한이 없습니다."),

--- a/src/main/java/yapp/buddycon/web/member/adapter/in/MemberController.java
+++ b/src/main/java/yapp/buddycon/web/member/adapter/in/MemberController.java
@@ -11,17 +11,19 @@ import yapp.buddycon.common.response.DefaultResponseDto;
 import yapp.buddycon.web.auth.adapter.out.AuthMember;
 import yapp.buddycon.web.member.adapter.in.request.NotificationSettingUpdateRequestDto;
 import yapp.buddycon.web.member.adapter.in.response.NotificationSettingResponseDto;
+import yapp.buddycon.web.member.application.port.in.MemberUseCase;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("api/v1/member")
 public class MemberController {
 
+  private final MemberUseCase memberUseCase;
+
   @GetMapping("/notification-setting")
   @Operation(summary = "유저 알림 설정 조회")
   public NotificationSettingResponseDto getNotificationSetting(AuthMember authMember) {
-    NotificationSettingResponseDto dto = null;
-    return dto;
+    return memberUseCase.getMembersNotificationSetting(authMember.id());
   }
 
   @PatchMapping("/notification-setting")

--- a/src/main/java/yapp/buddycon/web/member/adapter/out/NotificationSettingJpaRepository.java
+++ b/src/main/java/yapp/buddycon/web/member/adapter/out/NotificationSettingJpaRepository.java
@@ -1,0 +1,18 @@
+package yapp.buddycon.web.member.adapter.out;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import yapp.buddycon.web.member.adapter.in.response.NotificationSettingResponseDto;
+import yapp.buddycon.web.member.domain.NotificationSetting;
+
+public interface NotificationSettingJpaRepository extends JpaRepository<NotificationSetting, Long> {
+
+  @Query(value = """
+      select new yapp.buddycon.web.member.adapter.in.response.NotificationSettingResponseDto(ns.id, ns.activate, ns.fourteenDaysLeft, ns.sevenDaysLeft, ns.threeDaysLeft, ns.oneDaysLeft)
+      from NotificationSetting ns
+      where ns.member.id = :memberId
+  """)
+  Optional<NotificationSettingResponseDto> findByMemberId(long memberId);
+
+}

--- a/src/main/java/yapp/buddycon/web/member/adapter/out/NotificationSettingQueryRepository.java
+++ b/src/main/java/yapp/buddycon/web/member/adapter/out/NotificationSettingQueryRepository.java
@@ -1,0 +1,21 @@
+package yapp.buddycon.web.member.adapter.out;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import yapp.buddycon.common.exception.CustomException;
+import yapp.buddycon.common.exception.ErrorCode;
+import yapp.buddycon.web.member.adapter.in.response.NotificationSettingResponseDto;
+import yapp.buddycon.web.member.application.port.out.NotificationSettingQueryPort;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationSettingQueryRepository implements NotificationSettingQueryPort {
+
+  private final NotificationSettingJpaRepository notificationSettingJpaRepository;
+
+  @Override
+  public NotificationSettingResponseDto findByMemberId(long memberId) {
+    return notificationSettingJpaRepository.findByMemberId(memberId).orElseThrow(() -> new CustomException(ErrorCode.NOTIFICATION_SETTING_NOT_FOUND));
+  }
+
+}

--- a/src/main/java/yapp/buddycon/web/member/application/port/in/MemberUseCase.java
+++ b/src/main/java/yapp/buddycon/web/member/application/port/in/MemberUseCase.java
@@ -1,0 +1,9 @@
+package yapp.buddycon.web.member.application.port.in;
+
+import yapp.buddycon.web.member.adapter.in.response.NotificationSettingResponseDto;
+
+public interface MemberUseCase {
+
+  NotificationSettingResponseDto getMembersNotificationSetting(long memberId);
+
+}

--- a/src/main/java/yapp/buddycon/web/member/application/port/out/NotificationSettingQueryPort.java
+++ b/src/main/java/yapp/buddycon/web/member/application/port/out/NotificationSettingQueryPort.java
@@ -1,0 +1,9 @@
+package yapp.buddycon.web.member.application.port.out;
+
+import yapp.buddycon.web.member.adapter.in.response.NotificationSettingResponseDto;
+
+public interface NotificationSettingQueryPort {
+
+  NotificationSettingResponseDto findByMemberId(long memberId);
+
+}

--- a/src/main/java/yapp/buddycon/web/member/application/service/MemberService.java
+++ b/src/main/java/yapp/buddycon/web/member/application/service/MemberService.java
@@ -1,0 +1,21 @@
+package yapp.buddycon.web.member.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import yapp.buddycon.web.member.adapter.in.response.NotificationSettingResponseDto;
+import yapp.buddycon.web.member.application.port.in.MemberUseCase;
+import yapp.buddycon.web.member.application.port.out.NotificationSettingQueryPort;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberService implements MemberUseCase {
+
+  private final NotificationSettingQueryPort notificationSettingQueryPort;
+
+  @Override
+  public NotificationSettingResponseDto getMembersNotificationSetting(long memberId) {
+    return notificationSettingQueryPort.findByMemberId(memberId);
+  }
+}


### PR DESCRIPTION
## 개요

- 사용자 별 알림 설정 조회 API 추가

## 작업 내용

- `GET::/api/v1/member/notification-setting` API 추가

## 메모

close #48 
