### PR TITLE
[Issue #50] 제작티콘 추가 API

### DIFF
--- a/src/main/java/yapp/buddycon/common/exception/ErrorCode.java
+++ b/src/main/java/yapp/buddycon/common/exception/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
   TOKEN_MEMBER_INFO_IS_NOT_MATCH(BAD_REQUEST, "토큰의 사용자 정보가 일치하지 않습니다."),
 
   FAILED_TO_UPLOAD_IMAGE(BAD_REQUEST, "이미지 업로드가 실패하였습니다."),
+  IMAGE_NOT_FOUND(BAD_REQUEST, "이미지를 찾을 수 없습니다."),
 
   INVALID_SORT_PROPERTY(BAD_REQUEST, "잘못된 sort 방식입니다."),
 

--- a/src/main/java/yapp/buddycon/common/util/AwsS3FileProvider.java
+++ b/src/main/java/yapp/buddycon/common/util/AwsS3FileProvider.java
@@ -30,6 +30,11 @@ public class AwsS3FileProvider implements CouponToAwsS3Port {
 
   @Override
   public String upload(MultipartFile file) {
+    // empty file
+    if (file.isEmpty()) {
+      throw new CustomException(ErrorCode.IMAGE_NOT_FOUND);
+    }
+
     String s3PathKey = PATH_ROOT + "/" + UuidProvider.generateUuid();
     ObjectMetadata metaData = new ObjectMetadata();
     metaData.setContentLength(file.getSize());

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/in/CouponController.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/in/CouponController.java
@@ -57,10 +57,10 @@ public class CouponController {
     return couponUseCase.makeGifticon(gifticonCreationRequestDto, image, authMember);
   }
 
-  @PostMapping("/custom-coupon")
+  @PostMapping(value = "/custom-coupon", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
   @Operation(summary = "제작티콘 제작")
   public DefaultResponseDto makeCustomCoupon(@RequestPart CustomCouponCreationRequestDto customCouponCreationRequestDto, @RequestPart MultipartFile image, AuthMember authMember) {
-    return null;
+    return couponUseCase.makeCustomCoupon(customCouponCreationRequestDto, image, authMember);
   }
 
   @GetMapping("/gifticon/info")

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/in/request/CustomCouponCreationRequestDto.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/in/request/CustomCouponCreationRequestDto.java
@@ -7,6 +7,7 @@ public record CustomCouponCreationRequestDto(
   String name,
   LocalDate expireDate,
   String storeName,
-  String memo
+  String memo,
+  String sentMemberName
 ) {
 }

--- a/src/main/java/yapp/buddycon/web/coupon/application/port/in/CouponUseCase.java
+++ b/src/main/java/yapp/buddycon/web/coupon/application/port/in/CouponUseCase.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.web.multipart.MultipartFile;
 import yapp.buddycon.common.response.DefaultResponseDto;
 import yapp.buddycon.web.auth.adapter.out.AuthMember;
+import yapp.buddycon.web.coupon.adapter.in.request.CustomCouponCreationRequestDto;
 import yapp.buddycon.web.coupon.adapter.in.request.GifticonCreationRequestDto;
 import yapp.buddycon.web.coupon.adapter.in.response.CouponsResponseDto;
 import yapp.buddycon.web.coupon.adapter.in.response.*;
@@ -22,6 +23,7 @@ public interface CouponUseCase {
   CustomCouponInfoResponseDto getCustomCouponInfo(Long memberId, Long couponId);
 
   DefaultResponseDto makeGifticon(GifticonCreationRequestDto gifticonCreationRequestDto, MultipartFile image, AuthMember authMember);
+  DefaultResponseDto makeCustomCoupon(CustomCouponCreationRequestDto customCouponCreationRequestDto, MultipartFile image, AuthMember authMember);
 
   DefaultResponseDto deleteCoupon(Long memberId, Long couponId);
 

--- a/src/main/java/yapp/buddycon/web/coupon/application/service/CouponService.java
+++ b/src/main/java/yapp/buddycon/web/coupon/application/service/CouponService.java
@@ -65,9 +65,6 @@ public class CouponService implements CouponUseCase {
   @Override
   public DefaultResponseDto makeGifticon(GifticonCreationRequestDto gifticonCreationRequestDto,
       MultipartFile image, AuthMember authMember) {
-    // empty file
-    if (image.isEmpty()) return new DefaultResponseDto(false, "잘못된 이미지입니다.");
-
     // try to upload image
     String imageUrl = couponToAwsS3Port.upload(image);
 

--- a/src/main/java/yapp/buddycon/web/coupon/application/service/CouponService.java
+++ b/src/main/java/yapp/buddycon/web/coupon/application/service/CouponService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import yapp.buddycon.common.response.DefaultResponseDto;
 import yapp.buddycon.web.auth.adapter.out.AuthMember;
+import yapp.buddycon.web.coupon.adapter.in.request.CustomCouponCreationRequestDto;
 import yapp.buddycon.web.coupon.adapter.in.response.*;
 import yapp.buddycon.web.coupon.adapter.in.request.GifticonCreationRequestDto;
 import yapp.buddycon.web.coupon.adapter.in.response.CouponsResponseDto;
@@ -75,6 +76,21 @@ public class CouponService implements CouponUseCase {
     couponCommandPort.createCoupon(coupon);
 
     return new DefaultResponseDto(true, "기프티콘이 생성되었습니다.");
+  }
+
+  @Override
+  public DefaultResponseDto makeCustomCoupon(
+      CustomCouponCreationRequestDto customCouponCreationRequestDto, MultipartFile image, AuthMember authMember) {
+    // try to upload image
+    String imageUrl = couponToAwsS3Port.upload(image);
+
+    // create coupon
+    Coupon coupon = Coupon.create(couponToMemberQueryPort.findById(authMember.id()),
+        CouponInfo.valueOf(customCouponCreationRequestDto, imageUrl),
+        CouponType.CUSTOM);
+    couponCommandPort.createCoupon(coupon);
+
+    return new DefaultResponseDto(true, "제작티콘이 생성되었습니다.");
   }
 
   @Override

--- a/src/main/java/yapp/buddycon/web/coupon/application/service/CouponService.java
+++ b/src/main/java/yapp/buddycon/web/coupon/application/service/CouponService.java
@@ -29,6 +29,7 @@ import yapp.buddycon.web.coupon.domain.CouponType;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class CouponService implements CouponUseCase {
 
   private final CouponCommandPort couponCommandPort;
@@ -64,6 +65,7 @@ public class CouponService implements CouponUseCase {
   }
 
   @Override
+  @Transactional
   public DefaultResponseDto makeGifticon(GifticonCreationRequestDto gifticonCreationRequestDto,
       MultipartFile image, AuthMember authMember) {
     // try to upload image
@@ -79,6 +81,7 @@ public class CouponService implements CouponUseCase {
   }
 
   @Override
+  @Transactional
   public DefaultResponseDto makeCustomCoupon(
       CustomCouponCreationRequestDto customCouponCreationRequestDto, MultipartFile image, AuthMember authMember) {
     // try to upload image

--- a/src/main/java/yapp/buddycon/web/coupon/domain/CouponInfo.java
+++ b/src/main/java/yapp/buddycon/web/coupon/domain/CouponInfo.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import yapp.buddycon.web.coupon.adapter.in.request.CustomCouponCreationRequestDto;
 import yapp.buddycon.web.coupon.adapter.in.request.GifticonCreationRequestDto;
 
 @Embeddable
@@ -53,6 +54,18 @@ public class CouponInfo {
         .isMoneyCoupon(dto.isMoneyCoupon())
         .leftMoney(dto.leftMoney())
         .expireDate(dto.expireDate())
+        .build();
+  }
+
+  public static CouponInfo valueOf(CustomCouponCreationRequestDto dto, String imageUrl) {
+    return CouponInfo.builder()
+        .barcode(dto.barcode())
+        .imageUrl(imageUrl)
+        .name(dto.name())
+        .memo(dto.memo())
+        .storeName(dto.storeName())
+        .expireDate(dto.expireDate())
+        .sentMemberName(dto.sentMemberName())
         .build();
   }
 


### PR DESCRIPTION
## 개요

이미지와 함께 제작티콘 생성을 요청하는 API 추가

## 작업 내용

- `POST::/api/v1/coupon/custom-coupon` API 추가
- 빈 이미지 예외처리 시점 변경

## 메모

close #50 
