### PR TITLE
52 feature 유저 알림 설정 수정 api

### DIFF
--- a/src/main/java/yapp/buddycon/web/member/adapter/in/MemberController.java
+++ b/src/main/java/yapp/buddycon/web/member/adapter/in/MemberController.java
@@ -28,9 +28,8 @@ public class MemberController {
 
   @PatchMapping("/notification-setting")
   @Operation(summary = "유저 알림 설정 수정")
-  public DefaultResponseDto updateNotificationSetting(AuthMember authMember,
-      NotificationSettingUpdateRequestDto dto) {
-    return null;
+  public DefaultResponseDto updateNotificationSetting(AuthMember authMember, NotificationSettingUpdateRequestDto dto) {
+    return memberUseCase.updateNotificationSetting(authMember.id(), dto);
   }
 
   @DeleteMapping("/self")

--- a/src/main/java/yapp/buddycon/web/member/adapter/in/response/NotificationSettingResponseDto.java
+++ b/src/main/java/yapp/buddycon/web/member/adapter/in/response/NotificationSettingResponseDto.java
@@ -1,5 +1,7 @@
 package yapp.buddycon.web.member.adapter.in.response;
 
+import yapp.buddycon.web.member.domain.NotificationSetting;
+
 public record NotificationSettingResponseDto(
     long id,
     boolean activate,
@@ -8,5 +10,16 @@ public record NotificationSettingResponseDto(
     boolean threeDaysLeft,
     boolean oneDaysLeft
 ) {
+
+  public static NotificationSettingResponseDto valueOf(NotificationSetting notificationSetting) {
+    return new NotificationSettingResponseDto(
+        notificationSetting.getId(),
+        notificationSetting.isActivate(),
+        notificationSetting.isFourteenDaysLeft(),
+        notificationSetting.isSevenDaysLeft(),
+        notificationSetting.isThreeDaysLeft(),
+        notificationSetting.isOneDaysLeft()
+    );
+  }
 
 }

--- a/src/main/java/yapp/buddycon/web/member/adapter/out/NotificationSettingJpaRepository.java
+++ b/src/main/java/yapp/buddycon/web/member/adapter/out/NotificationSettingJpaRepository.java
@@ -2,17 +2,10 @@ package yapp.buddycon.web.member.adapter.out;
 
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import yapp.buddycon.web.member.adapter.in.response.NotificationSettingResponseDto;
 import yapp.buddycon.web.member.domain.NotificationSetting;
 
 public interface NotificationSettingJpaRepository extends JpaRepository<NotificationSetting, Long> {
 
-  @Query(value = """
-      select new yapp.buddycon.web.member.adapter.in.response.NotificationSettingResponseDto(ns.id, ns.activate, ns.fourteenDaysLeft, ns.sevenDaysLeft, ns.threeDaysLeft, ns.oneDaysLeft)
-      from NotificationSetting ns
-      where ns.member.id = :memberId
-  """)
-  Optional<NotificationSettingResponseDto> findByMemberId(long memberId);
+  Optional<NotificationSetting> findByMemberId(long memberId);
 
 }

--- a/src/main/java/yapp/buddycon/web/member/adapter/out/NotificationSettingQueryRepository.java
+++ b/src/main/java/yapp/buddycon/web/member/adapter/out/NotificationSettingQueryRepository.java
@@ -4,8 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import yapp.buddycon.common.exception.CustomException;
 import yapp.buddycon.common.exception.ErrorCode;
-import yapp.buddycon.web.member.adapter.in.response.NotificationSettingResponseDto;
 import yapp.buddycon.web.member.application.port.out.NotificationSettingQueryPort;
+import yapp.buddycon.web.member.domain.NotificationSetting;
 
 @Repository
 @RequiredArgsConstructor
@@ -14,7 +14,7 @@ public class NotificationSettingQueryRepository implements NotificationSettingQu
   private final NotificationSettingJpaRepository notificationSettingJpaRepository;
 
   @Override
-  public NotificationSettingResponseDto findByMemberId(long memberId) {
+  public NotificationSetting findByMemberId(long memberId) {
     return notificationSettingJpaRepository.findByMemberId(memberId).orElseThrow(() -> new CustomException(ErrorCode.NOTIFICATION_SETTING_NOT_FOUND));
   }
 

--- a/src/main/java/yapp/buddycon/web/member/application/port/in/MemberUseCase.java
+++ b/src/main/java/yapp/buddycon/web/member/application/port/in/MemberUseCase.java
@@ -1,9 +1,13 @@
 package yapp.buddycon.web.member.application.port.in;
 
+import yapp.buddycon.common.response.DefaultResponseDto;
+import yapp.buddycon.web.member.adapter.in.request.NotificationSettingUpdateRequestDto;
 import yapp.buddycon.web.member.adapter.in.response.NotificationSettingResponseDto;
 
 public interface MemberUseCase {
 
   NotificationSettingResponseDto getMembersNotificationSetting(long memberId);
+
+  DefaultResponseDto updateNotificationSetting(long memberId, NotificationSettingUpdateRequestDto dto);
 
 }

--- a/src/main/java/yapp/buddycon/web/member/application/port/out/NotificationSettingQueryPort.java
+++ b/src/main/java/yapp/buddycon/web/member/application/port/out/NotificationSettingQueryPort.java
@@ -1,9 +1,9 @@
 package yapp.buddycon.web.member.application.port.out;
 
-import yapp.buddycon.web.member.adapter.in.response.NotificationSettingResponseDto;
+import yapp.buddycon.web.member.domain.NotificationSetting;
 
 public interface NotificationSettingQueryPort {
 
-  NotificationSettingResponseDto findByMemberId(long memberId);
+  NotificationSetting findByMemberId(long memberId);
 
 }

--- a/src/main/java/yapp/buddycon/web/member/application/service/MemberService.java
+++ b/src/main/java/yapp/buddycon/web/member/application/service/MemberService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import yapp.buddycon.web.member.adapter.in.response.NotificationSettingResponseDto;
 import yapp.buddycon.web.member.application.port.in.MemberUseCase;
 import yapp.buddycon.web.member.application.port.out.NotificationSettingQueryPort;
+import yapp.buddycon.web.member.domain.NotificationSetting;
 
 @Service
 @RequiredArgsConstructor
@@ -16,6 +17,7 @@ public class MemberService implements MemberUseCase {
 
   @Override
   public NotificationSettingResponseDto getMembersNotificationSetting(long memberId) {
-    return notificationSettingQueryPort.findByMemberId(memberId);
+    NotificationSetting notificationSetting = notificationSettingQueryPort.findByMemberId(memberId);
+    return NotificationSettingResponseDto.valueOf(notificationSetting);
   }
 }

--- a/src/main/java/yapp/buddycon/web/member/application/service/MemberService.java
+++ b/src/main/java/yapp/buddycon/web/member/application/service/MemberService.java
@@ -3,6 +3,8 @@ package yapp.buddycon.web.member.application.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import yapp.buddycon.common.response.DefaultResponseDto;
+import yapp.buddycon.web.member.adapter.in.request.NotificationSettingUpdateRequestDto;
 import yapp.buddycon.web.member.adapter.in.response.NotificationSettingResponseDto;
 import yapp.buddycon.web.member.application.port.in.MemberUseCase;
 import yapp.buddycon.web.member.application.port.out.NotificationSettingQueryPort;
@@ -20,4 +22,13 @@ public class MemberService implements MemberUseCase {
     NotificationSetting notificationSetting = notificationSettingQueryPort.findByMemberId(memberId);
     return NotificationSettingResponseDto.valueOf(notificationSetting);
   }
+
+  @Override
+  @Transactional
+  public DefaultResponseDto updateNotificationSetting(long memberId, NotificationSettingUpdateRequestDto dto) {
+    NotificationSetting notificationSetting = notificationSettingQueryPort.findByMemberId(memberId);
+    notificationSetting.update(dto);
+    return new DefaultResponseDto(true, "알림 설정을 수정하였습니다.");
+  }
+
 }

--- a/src/main/java/yapp/buddycon/web/member/domain/NotificationSetting.java
+++ b/src/main/java/yapp/buddycon/web/member/domain/NotificationSetting.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import yapp.buddycon.common.domain.BaseEntity;
+import yapp.buddycon.web.member.adapter.in.request.NotificationSettingUpdateRequestDto;
 
 @Entity
 @Getter
@@ -40,5 +41,13 @@ public class NotificationSetting extends BaseEntity {
       .threeDaysLeft(false)
       .oneDaysLeft(true)
       .build();
+  }
+
+  public void update(NotificationSettingUpdateRequestDto dto) {
+    this.activate = dto.activate();
+    this.fourteenDaysLeft = dto.fourteenDaysLeft();
+    this.sevenDaysLeft = dto.sevenDaysLeft();
+    this.threeDaysLeft = dto.threeDaysLeft();
+    this.oneDaysLeft = dto.oneDaysLeft();
   }
 }

--- a/src/main/java/yapp/buddycon/web/member/domain/NotificationSetting.java
+++ b/src/main/java/yapp/buddycon/web/member/domain/NotificationSetting.java
@@ -5,10 +5,12 @@ import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import yapp.buddycon.common.domain.BaseEntity;
 
 @Entity
+@Getter
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder


### PR DESCRIPTION
## 개요

유저 알림 설정 수정 API 추가

## 작업 내용

- 유저 알림 설정 조회 시 엔티티로 조회 후 ResponseDto로 파싱하도록 수정
- `patch::/api/v1/member/notification-setting` API 추가

## 메모

close #52 
