### PR TITLE
[Issue #55] 회원탈퇴 api

### DIFF
--- a/src/main/java/yapp/buddycon/common/exception/ErrorCode.java
+++ b/src/main/java/yapp/buddycon/common/exception/ErrorCode.java
@@ -36,6 +36,8 @@ public enum ErrorCode {
   INVALID_PAGE(BAD_REQUEST, "올바르지 않은 page 입니다."),
   INVALID_SIZE(BAD_REQUEST, "올바르지 않은 size 입니다."),
 
+  DELETED_MEMBER(BAD_REQUEST, "탈퇴한 회원입니다."),
+
   /* 403 FORBIDDEN */
   CANT_ACCESS_NOTIFICATION(FORBIDDEN, "해당 알림에 대한 권한이 없습니다."),
 

--- a/src/main/java/yapp/buddycon/web/auth/application/service/AuthService.java
+++ b/src/main/java/yapp/buddycon/web/auth/application/service/AuthService.java
@@ -33,11 +33,8 @@ public class AuthService implements AuthUseCase {
     if (member == null){
       member = Member.create(oAuthMemberInfo.id(), kakaoInfoRequestDto.email(), kakaoInfoRequestDto.name(), kakaoInfoRequestDto.gender(), kakaoInfoRequestDto.ageRange());
     }
+    if(member.isDeleted()) throw new CustomException(ErrorCode.DELETED_MEMBER);
     return tokenProvider.createToken(member.getId());
-  }
-
-  private Member signup(OAuthMemberInfo oAuthMemberInfo, KakaoInfoRequestDto kakaoInfoRequestDto) {
-    return authToMemberCommandPort.save(new Member(oAuthMemberInfo.id(), kakaoInfoRequestDto.email(), kakaoInfoRequestDto.name(), kakaoInfoRequestDto.gender(), kakaoInfoRequestDto.ageRange()));
   }
 
   @Transactional

--- a/src/main/java/yapp/buddycon/web/member/adapter/in/MemberController.java
+++ b/src/main/java/yapp/buddycon/web/member/adapter/in/MemberController.java
@@ -36,7 +36,7 @@ public class MemberController {
   @DeleteMapping("/self")
   @Operation(summary = "회원 탈퇴")
   public DefaultResponseDto deleteMember(AuthMember authMember) {
-    return null;
+    return memberUseCase.deleteMember(authMember.id());
   }
 
 }

--- a/src/main/java/yapp/buddycon/web/member/application/port/in/MemberUseCase.java
+++ b/src/main/java/yapp/buddycon/web/member/application/port/in/MemberUseCase.java
@@ -1,9 +1,12 @@
 package yapp.buddycon.web.member.application.port.in;
 
+import yapp.buddycon.common.response.DefaultResponseDto;
 import yapp.buddycon.web.member.adapter.in.response.NotificationSettingResponseDto;
 
 public interface MemberUseCase {
 
   NotificationSettingResponseDto getMembersNotificationSetting(long memberId);
+
+  DefaultResponseDto deleteMember(Long id);
 
 }

--- a/src/main/java/yapp/buddycon/web/member/application/port/out/MemberQueryPort.java
+++ b/src/main/java/yapp/buddycon/web/member/application/port/out/MemberQueryPort.java
@@ -1,4 +1,8 @@
 package yapp.buddycon.web.member.application.port.out;
 
+
+import yapp.buddycon.web.member.domain.Member;
+
 public interface MemberQueryPort {
+  Member findById(long id);
 }

--- a/src/main/java/yapp/buddycon/web/member/application/service/MemberService.java
+++ b/src/main/java/yapp/buddycon/web/member/application/service/MemberService.java
@@ -3,19 +3,33 @@ package yapp.buddycon.web.member.application.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import yapp.buddycon.common.response.DefaultResponseDto;
 import yapp.buddycon.web.member.adapter.in.response.NotificationSettingResponseDto;
 import yapp.buddycon.web.member.application.port.in.MemberUseCase;
+import yapp.buddycon.web.member.application.port.out.MemberCommandPort;
+import yapp.buddycon.web.member.application.port.out.MemberQueryPort;
 import yapp.buddycon.web.member.application.port.out.NotificationSettingQueryPort;
+import yapp.buddycon.web.member.domain.Member;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class MemberService implements MemberUseCase {
 
   private final NotificationSettingQueryPort notificationSettingQueryPort;
+  private final MemberQueryPort memberQueryPort;
+  private final MemberCommandPort memberCommandPort;
 
   @Override
+  @Transactional(readOnly = true)
   public NotificationSettingResponseDto getMembersNotificationSetting(long memberId) {
     return notificationSettingQueryPort.findByMemberId(memberId);
+  }
+
+  @Override
+  @Transactional
+  public DefaultResponseDto deleteMember(Long id) {
+    Member member = memberQueryPort.findById(id);
+    member.delete();
+    return new DefaultResponseDto(true, "탈퇴되었어요");
   }
 }

--- a/src/main/java/yapp/buddycon/web/member/domain/Member.java
+++ b/src/main/java/yapp/buddycon/web/member/domain/Member.java
@@ -2,6 +2,7 @@ package yapp.buddycon.web.member.domain;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import yapp.buddycon.common.domain.BaseEntity;
 
@@ -11,6 +12,7 @@ import javax.persistence.*;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@Getter
 public class Member extends BaseEntity {
 
   @Column(name = "client_id", unique = true)
@@ -28,6 +30,9 @@ public class Member extends BaseEntity {
   @Column(name = "age_range")
   private String ageRange;
 
+  @Column(name = "deleted")
+  private boolean deleted;
+
   public static Member create(Long clientId, String email, String name, String gender, String ageRange) {
     return Member.builder()
       .clientId(clientId)
@@ -35,7 +40,12 @@ public class Member extends BaseEntity {
       .name(name)
       .gender(gender)
       .ageRange(ageRange)
+      .deleted(false)
       .build();
+  }
+
+  public void delete() {
+    this.deleted = true;
   }
 
 }


### PR DESCRIPTION
## 개요
회원탈퇴 api 구현

## 작업 내용
회원탈퇴 api를 구현하였습니다.
회원 탈퇴에 따른 다른 도메인의 deleted처리는 추후 이슈를 파서 구현하도록 하겠습니다.

## 메모

close #55 
