### PR TITLE
[Issue #57] 만든 쿠폰 삭제 api

### DIFF
--- a/src/main/java/yapp/buddycon/web/coupon/adapter/in/SharedCouponController.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/in/SharedCouponController.java
@@ -34,6 +34,6 @@ public class SharedCouponController {
   @DeleteMapping("/{id}")
   @Operation(summary = "만든쿠폰 삭제")
   public DefaultResponseDto deleteSharedCoupon(@PathVariable("id") long id, AuthMember authMember) {
-    return null;
+    return sharedCouponUseCase.deleteSharedCoupon(authMember.id(), id);
   }
 }

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/out/SharedCouponJpaRepository.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/out/SharedCouponJpaRepository.java
@@ -45,4 +45,12 @@ public interface SharedCouponJpaRepository extends JpaRepository<SharedCoupon, L
     where s.sharedCouponInfo.sentMember.id = :memberId
   """)
   List<SharedCouponsResponseDto> findCustomCouponsSortedBy(Long memberId, Pageable pageable);
+
+  @Query(value = """
+    select s
+    from SharedCoupon s
+    where s.sharedCouponInfo.sentMember.id = :memberId
+    and s.coupon.id = :id
+  """)
+  Optional<SharedCoupon> findByIdAndMemberId(Long id, Long memberId);
 }

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/out/SharedCouponQueryRepository.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/out/SharedCouponQueryRepository.java
@@ -10,6 +10,7 @@ import yapp.buddycon.web.coupon.adapter.in.response.SharedCustomCouponResponseDt
 import yapp.buddycon.web.coupon.adapter.in.response.SharedGifticonInfoResponseDto;
 import yapp.buddycon.web.coupon.application.port.out.CouponToSharedCouponQueryPort;
 import yapp.buddycon.web.coupon.application.port.out.SharedCouponQueryPort;
+import yapp.buddycon.web.coupon.domain.SharedCoupon;
 
 import java.util.List;
 
@@ -37,5 +38,10 @@ public class SharedCouponQueryRepository implements SharedCouponQueryPort, Coupo
   @Override
   public List<SharedCouponsResponseDto> findCustomCouponsSortedBy(Long memberId, Pageable pageable) {
     return sharedCouponJpaRepository.findCustomCouponsSortedBy(memberId, pageable);
+  }
+
+  @Override
+  public SharedCoupon findByIdAndMemberId(Long couponId, Long memberId) {
+    return sharedCouponJpaRepository.findByIdAndMemberId(couponId, memberId).orElseThrow(() -> new CustomException(ErrorCode.INVALID_COUPON_ID));
   }
 }

--- a/src/main/java/yapp/buddycon/web/coupon/application/port/in/SharedCouponUseCase.java
+++ b/src/main/java/yapp/buddycon/web/coupon/application/port/in/SharedCouponUseCase.java
@@ -1,10 +1,13 @@
 package yapp.buddycon.web.coupon.application.port.in;
 
 import org.springframework.data.domain.Pageable;
+import yapp.buddycon.common.response.DefaultResponseDto;
 import yapp.buddycon.web.coupon.adapter.in.response.SharedCouponsResponseDto;
 
 import java.util.List;
 
 public interface SharedCouponUseCase {
   List<SharedCouponsResponseDto> getSortedSharedCoupons(boolean unshared, Pageable pageable, Long memberId);
+
+  DefaultResponseDto deleteSharedCoupon(Long memberId, Long couponId);
 }

--- a/src/main/java/yapp/buddycon/web/coupon/application/port/out/SharedCouponQueryPort.java
+++ b/src/main/java/yapp/buddycon/web/coupon/application/port/out/SharedCouponQueryPort.java
@@ -2,6 +2,7 @@ package yapp.buddycon.web.coupon.application.port.out;
 
 import org.springframework.data.domain.Pageable;
 import yapp.buddycon.web.coupon.adapter.in.response.SharedCouponsResponseDto;
+import yapp.buddycon.web.coupon.domain.SharedCoupon;
 
 import java.util.List;
 
@@ -9,4 +10,6 @@ public interface SharedCouponQueryPort {
 
   List<SharedCouponsResponseDto> findUnsharedCustomCouponsSortedBy(Long memberId, Pageable pageable);
   List<SharedCouponsResponseDto> findCustomCouponsSortedBy(Long memberId, Pageable pageable);
+
+  SharedCoupon findByIdAndMemberId(Long couponId, Long memberId);
 }

--- a/src/main/java/yapp/buddycon/web/coupon/application/service/SharedCouponService.java
+++ b/src/main/java/yapp/buddycon/web/coupon/application/service/SharedCouponService.java
@@ -5,10 +5,13 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import yapp.buddycon.common.response.DefaultResponseDto;
 import yapp.buddycon.web.coupon.adapter.in.response.SharedCouponsResponseDto;
 import yapp.buddycon.web.coupon.application.port.in.SharedCouponUseCase;
 import yapp.buddycon.web.coupon.application.port.out.SharedCouponCommandPort;
 import yapp.buddycon.web.coupon.application.port.out.SharedCouponQueryPort;
+import yapp.buddycon.web.coupon.domain.SharedCoupon;
 
 import java.util.List;
 
@@ -25,5 +28,13 @@ public class SharedCouponService implements SharedCouponUseCase {
     PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
     if(unshared) return sharedCouponQueryPort.findUnsharedCustomCouponsSortedBy(memberId, pageRequest);
     else return sharedCouponQueryPort.findCustomCouponsSortedBy(memberId, pageRequest);
+  }
+
+  @Override
+  @Transactional
+  public DefaultResponseDto deleteSharedCoupon(Long memberId, Long couponId) {
+    SharedCoupon sharedCoupon = sharedCouponQueryPort.findByIdAndMemberId(couponId, memberId);
+    sharedCoupon.delete();
+    return new DefaultResponseDto(true, "쿠폰을 삭제하였습니다.");
   }
 }

--- a/src/main/java/yapp/buddycon/web/coupon/domain/SharedCoupon.java
+++ b/src/main/java/yapp/buddycon/web/coupon/domain/SharedCoupon.java
@@ -21,4 +21,11 @@ public class SharedCoupon extends BaseEntity {
   @Column(name = "shared")
   private boolean shared;
 
+  @Column(name = "deleted")
+  private boolean deleted;
+
+  public void delete() {
+    this.deleted = true;
+  }
+
 }


### PR DESCRIPTION
## 개요
만든 쿠폰 삭제 api 구현

## 작업 내용
만든 쿠폰 삭제 api 구현

## 메모
만든 쿠폰 삭제 api를 soft delete로 구현함에 따라, '만든쿠폰 정렬'등의 다른 api에서 추가적인 리팩토링 작업이 필요합니다.
이는 추후 이슈를 파서 구현하도록 하겠습니다.

close #57 
