### PR TITLE
[Issue #72] soft-delete 관련 로직 수정

### DIFF
--- a/src/main/java/yapp/buddycon/web/coupon/adapter/out/CouponJpaRepository.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/out/CouponJpaRepository.java
@@ -20,7 +20,7 @@ import java.util.Optional;
 public interface CouponJpaRepository extends JpaRepository<Coupon, Long> {
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)
-  Optional<Coupon> findById(Long id);
+  Optional<Coupon> findByIdAndDeletedFalse(Long id);
 
   @Query(value = """
     select new yapp.buddycon.web.coupon.adapter.in.response.CouponsResponseDto(c.id, c.couponInfo.imageUrl, c.couponInfo.name, c.couponInfo.expireDate, c.createdAt)
@@ -28,6 +28,7 @@ public interface CouponJpaRepository extends JpaRepository<Coupon, Long> {
     where c.state = :state
     and c.couponType = 'REAL'
     and c.member.id = :memberId
+    and c.deleted = false
   """)
   List<CouponsResponseDto> findSortedGifticonsAccordingToState(@Param("state") CouponState state, Long memberId, Pageable pageable);
 
@@ -37,6 +38,7 @@ public interface CouponJpaRepository extends JpaRepository<Coupon, Long> {
     where c.state = :state
     and c.couponType = 'CUSTOM'
     and c.member.id = :memberId
+    and c.deleted = false
   """)
   List<CouponsResponseDto> findSortedCustomCouponsAccordingToState(@Param("state") CouponState state, Long memberId, Pageable pageable);
 
@@ -46,6 +48,7 @@ public interface CouponJpaRepository extends JpaRepository<Coupon, Long> {
     where c.member.id = :memberId
     and c.id = :id
     and c.couponType = 'REAL'
+    and c.deleted = false
   """)
   GifticonInfoResponseDto findGifticonByMemberIdAndIdAndCouponType(Long memberId, Long id);
 
@@ -55,6 +58,7 @@ public interface CouponJpaRepository extends JpaRepository<Coupon, Long> {
     where c.member.id = :memberId
     and c.id = :id
     and c.couponType = 'CUSTOM'
+    and c.deleted = false
   """)
   CustomCouponInfoResponseDto findCustomCouponByMemberIdAndIdAndCouponType(Long memberId, Long id);
 
@@ -64,6 +68,7 @@ public interface CouponJpaRepository extends JpaRepository<Coupon, Long> {
     set c.state = 'USED'
     where c.member.id = :memberId
     and c.id = :couponId
+    and c.deleted = false
   """
   )
   void changeStateUsableToUsed(Long memberId, Long couponId);
@@ -76,6 +81,7 @@ public interface CouponJpaRepository extends JpaRepository<Coupon, Long> {
     and c.id = :couponId
     and c.state = 'USED'
     and c.couponInfo.expireDate > :today
+    and c.deleted = false
   """)
   Optional<Coupon> findCouponInUsedStateAndNotExpiredWithLock(Long memberId, Long couponId, LocalDate today);
 
@@ -85,6 +91,7 @@ public interface CouponJpaRepository extends JpaRepository<Coupon, Long> {
     set c.state = 'USABLE'
     where c.member.id = :memberId
     and c.id = :couponId
+    and c.deleted = false
   """
   )
   void changeStateUsedToUsable(Long memberId, Long couponId);

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/out/CouponQueryRepository.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/out/CouponQueryRepository.java
@@ -54,7 +54,7 @@ public class CouponQueryRepository implements CouponQueryPort {
 
   @Override
   public Coupon findById(Long id) {
-    return couponJpaRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.INVALID_COUPON_ID));
+    return couponJpaRepository.findByIdAndDeletedFalse(id).orElseThrow(() -> new CustomException(ErrorCode.INVALID_COUPON_ID));
   }
 
   @Override

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/out/SharedCouponJpaRepository.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/out/SharedCouponJpaRepository.java
@@ -18,6 +18,7 @@ public interface SharedCouponJpaRepository extends JpaRepository<SharedCoupon, L
     where s.sharedCouponInfo.barcode = :barcode
     and s.coupon.couponType = 'REAL'
     and s.shared = false
+    and s.deleted = false
   """)
   Optional<SharedGifticonInfoResponseDto> findSharedGifticonByBarcode(String barcode);
 
@@ -27,6 +28,7 @@ public interface SharedCouponJpaRepository extends JpaRepository<SharedCoupon, L
     where s.sharedCouponInfo.barcode = :barcode
     and s.coupon.couponType = 'CUSTOM'
     and s.shared = false
+    and s.deleted = false
   """)
   Optional<SharedCustomCouponResponseDto> findSharedCustomCouponByBarcode(String barcode);
 
@@ -35,6 +37,7 @@ public interface SharedCouponJpaRepository extends JpaRepository<SharedCoupon, L
     select new yapp.buddycon.web.coupon.adapter.in.response.SharedCouponsResponseDto(s.id, s.sharedCouponInfo.imageUrl, s.sharedCouponInfo.name, s.sharedCouponInfo.expireDate, s.createdAt, s.shared)
     from SharedCoupon s
     where s.sharedCouponInfo.sentMember.id = :memberId
+    and s.deleted = false
     order by s.shared
   """)
   List<SharedCouponsResponseDto> findUnsharedCustomCouponsSortedBy(Long memberId, Pageable pageable);
@@ -43,6 +46,7 @@ public interface SharedCouponJpaRepository extends JpaRepository<SharedCoupon, L
     select new yapp.buddycon.web.coupon.adapter.in.response.SharedCouponsResponseDto(s.id, s.sharedCouponInfo.imageUrl, s.sharedCouponInfo.name, s.sharedCouponInfo.expireDate, s.createdAt, s.shared)
     from SharedCoupon s
     where s.sharedCouponInfo.sentMember.id = :memberId
+    and s.deleted = false
   """)
   List<SharedCouponsResponseDto> findCustomCouponsSortedBy(Long memberId, Pageable pageable);
 
@@ -51,6 +55,7 @@ public interface SharedCouponJpaRepository extends JpaRepository<SharedCoupon, L
     from SharedCoupon s
     where s.sharedCouponInfo.sentMember.id = :memberId
     and s.coupon.id = :id
+    and s.deleted = false
   """)
   Optional<SharedCoupon> findByIdAndMemberId(Long id, Long memberId);
 }

--- a/src/main/java/yapp/buddycon/web/coupon/domain/SharedCoupon.java
+++ b/src/main/java/yapp/buddycon/web/coupon/domain/SharedCoupon.java
@@ -21,12 +21,12 @@ public class SharedCoupon extends BaseEntity {
   @Column(name = "shared")
   private boolean shared;
 
+  @Column(name = "deleted")
+  private boolean deleted;
+
   public void changeToSharedState() {
     this.shared = true;
   }
-
-  @Column(name = "deleted")
-  private boolean deleted;
 
   public void delete() {
     this.deleted = true;

--- a/src/main/java/yapp/buddycon/web/member/adapter/out/MemberJpaRepository.java
+++ b/src/main/java/yapp/buddycon/web/member/adapter/out/MemberJpaRepository.java
@@ -4,5 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import yapp.buddycon.web.member.domain.Member;
 
 interface MemberJpaRepository extends JpaRepository<Member, Long> {
-  Member findMemberByClientId(Long clientId);
+  Member findMemberByClientIdAndDeletedFalse(Long clientId);
 }

--- a/src/main/java/yapp/buddycon/web/member/adapter/out/MemberQueryRepository.java
+++ b/src/main/java/yapp/buddycon/web/member/adapter/out/MemberQueryRepository.java
@@ -18,7 +18,7 @@ class MemberQueryRepository implements MemberQueryPort,
 
     @Override
     public Member findMemberByClientId(Long clientId) {
-        return memberJpaRepository.findMemberByClientId(clientId);
+        return memberJpaRepository.findMemberByClientIdAndDeletedFalse(clientId);
     }
 
     @Override


### PR DESCRIPTION
## 개요

엔티티를 soft-delete 방식으로 삭제함에 따라 관련 로직 수정

## 작업 내용

- 관련 엔티티 접근 시 항상 deleted 컬럼을 확인하도록 수정
  - Member
  - Coupon
  - SharedCoupon

## 메모

close #72 
