### PR TITLE
[Issue #76] 쿠폰 등록 시 request dto에 sharedCouponId 추가

### DIFF
--- a/src/main/java/yapp/buddycon/web/coupon/adapter/in/request/CustomCouponCreationRequestDto.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/in/request/CustomCouponCreationRequestDto.java
@@ -3,6 +3,7 @@ package yapp.buddycon.web.coupon.adapter.in.request;
 import java.time.LocalDate;
 
 public record CustomCouponCreationRequestDto(
+  Long sharedCouponId,
   String barcode,
   String name,
   LocalDate expireDate,

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/in/request/GifticonCreationRequestDto.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/in/request/GifticonCreationRequestDto.java
@@ -3,6 +3,7 @@ package yapp.buddycon.web.coupon.adapter.in.request;
 import java.time.LocalDate;
 
 public record GifticonCreationRequestDto(
+  Long sharedCouponId,
   String barcode,
   String name,
   LocalDate expireDate,

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/out/SharedCouponQueryRepository.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/out/SharedCouponQueryRepository.java
@@ -31,6 +31,11 @@ public class SharedCouponQueryRepository implements SharedCouponQueryPort, Coupo
   }
 
   @Override
+  public SharedCoupon findById(long id) {
+    return sharedCouponJpaRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.INVALID_COUPON_ID));
+  }
+
+  @Override
   public List<SharedCouponsResponseDto> findUnsharedCustomCouponsSortedBy(Long memberId, Pageable pageable) {
     return sharedCouponJpaRepository.findUnsharedCustomCouponsSortedBy(memberId, pageable);
   }

--- a/src/main/java/yapp/buddycon/web/coupon/application/port/out/CouponToSharedCouponQueryPort.java
+++ b/src/main/java/yapp/buddycon/web/coupon/application/port/out/CouponToSharedCouponQueryPort.java
@@ -2,9 +2,12 @@ package yapp.buddycon.web.coupon.application.port.out;
 
 import yapp.buddycon.web.coupon.adapter.in.response.SharedCustomCouponResponseDto;
 import yapp.buddycon.web.coupon.adapter.in.response.SharedGifticonInfoResponseDto;
+import yapp.buddycon.web.coupon.domain.SharedCoupon;
 
 public interface CouponToSharedCouponQueryPort {
 
   SharedGifticonInfoResponseDto findSharedGifticonByBarcode(String barcode);
   SharedCustomCouponResponseDto findSharedCustomCouponByBarcode(String barcode);
+
+  SharedCoupon findById(long id);
 }

--- a/src/main/java/yapp/buddycon/web/coupon/application/service/CouponService.java
+++ b/src/main/java/yapp/buddycon/web/coupon/application/service/CouponService.java
@@ -81,6 +81,8 @@ public class CouponService implements CouponUseCase {
         CouponType.REAL);
     couponCommandPort.createCoupon(coupon);
 
+    if(gifticonCreationRequestDto.sharedCouponId() != null) couponToSharedCouponQueryPort.findById(gifticonCreationRequestDto.sharedCouponId()).save();
+
     return new DefaultResponseDto(true, "기프티콘이 생성되었습니다.");
   }
 
@@ -96,6 +98,8 @@ public class CouponService implements CouponUseCase {
         CouponInfo.valueOf(customCouponCreationRequestDto, imageUrl),
         CouponType.CUSTOM);
     couponCommandPort.createCoupon(coupon);
+
+    if(customCouponCreationRequestDto.sharedCouponId() != null) couponToSharedCouponQueryPort.findById(customCouponCreationRequestDto.sharedCouponId()).save();
 
     return new DefaultResponseDto(true, "제작티콘이 생성되었습니다.");
   }

--- a/src/main/java/yapp/buddycon/web/coupon/domain/SharedCoupon.java
+++ b/src/main/java/yapp/buddycon/web/coupon/domain/SharedCoupon.java
@@ -35,4 +35,8 @@ public class SharedCoupon extends BaseEntity {
     this.deleted = true;
   }
 
+  public void save(){
+    this.saved = true;
+  }
+
 }


### PR DESCRIPTION
## 개요
쿠폰 등록 시 request dto에 sharedCouponId 추가

## 작업 내용
- 쿠폰 등록 request dto에 sharedCouponId 추가
- 등록 시 해당하는 SharedCoupon의 saved=true로 변경

## 메모

close #76 
