### PR TITLE
[Issue #79] 쿠폰 공유 완료 시 해당 쿠폰 공유 완료 처리

### DIFF
--- a/src/main/java/yapp/buddycon/web/coupon/application/service/SharedCouponService.java
+++ b/src/main/java/yapp/buddycon/web/coupon/application/service/SharedCouponService.java
@@ -47,7 +47,7 @@ public class SharedCouponService implements SharedCouponUseCase {
   @Transactional
   public DefaultResponseDto changeCustomCouponState(Long couponId, Long memberId) {
     SharedCoupon sharedCoupon = sharedCouponQueryPort.findByIdAndMemberId(couponId, memberId);
-    sharedCoupon.changeToSharedState();
+    sharedCoupon.changeSharedCouponAndCouponSateToShared();
     return new DefaultResponseDto(true, "공유완료 상태로 변경되었습니다");
   }
 

--- a/src/main/java/yapp/buddycon/web/coupon/domain/Coupon.java
+++ b/src/main/java/yapp/buddycon/web/coupon/domain/Coupon.java
@@ -46,6 +46,10 @@ public class Coupon extends BaseEntity {
         .build();
   }
 
+  public void changeToSharedState() {
+    this.state = CouponState.SHARED;
+  }
+
   public void updateCouponInfo(GifticonInfoEditRequestDto dto) {
     this.couponInfo.update(dto);
   }

--- a/src/main/java/yapp/buddycon/web/coupon/domain/SharedCoupon.java
+++ b/src/main/java/yapp/buddycon/web/coupon/domain/SharedCoupon.java
@@ -32,8 +32,9 @@ public class SharedCoupon extends BaseEntity {
   @Column(name = "deleted")
   private boolean deleted;
 
-  public void changeToSharedState() {
+  public void changeSharedCouponAndCouponSateToShared() {
     this.shared = true;
+    coupon.changeToSharedState();
   }
 
   public void delete() {


### PR DESCRIPTION
## 개요

쿠폰 공유 완료 시 해당 쿠폰 공유 완료 처리

## 작업 내용

- 쿠폰 공유 완료 시 해당 쿠폰을 공유 완료 상태로 변경하도록 수정하였습니다.

## 메모

- https://github.com/YAPP-Github/21st-Android-Team-1-BE/pull/80 PR 머지 후 머지 부탁드립니다~

close #79
