### PR TITLE
[hotfix] 기프티콘 상세 조회 response dto에 sentMemberName 추가

### DIFF
--- a/src/main/java/yapp/buddycon/web/coupon/adapter/in/response/GifticonInfoResponseDto.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/in/response/GifticonInfoResponseDto.java
@@ -9,6 +9,7 @@ public record GifticonInfoResponseDto(
   String name,
   LocalDate expireDate,
   String storeName,
+  String sentMemberName,
   String memo,
   boolean isMoneyCoupon,
   Integer leftMoney

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/out/CouponJpaRepository.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/out/CouponJpaRepository.java
@@ -43,7 +43,7 @@ public interface CouponJpaRepository extends JpaRepository<Coupon, Long> {
   List<CouponsResponseDto> findSortedCustomCouponsAccordingToState(@Param("state") CouponState state, Long memberId, Pageable pageable);
 
   @Query(value = """
-    select new yapp.buddycon.web.coupon.adapter.in.response.GifticonInfoResponseDto(c.id, c.couponInfo.imageUrl, c.couponInfo.barcode, c.couponInfo.name, c.couponInfo.expireDate, c.couponInfo.storeName, c.couponInfo.memo, c.couponInfo.isMoneyCoupon, c.couponInfo.leftMoney)
+    select new yapp.buddycon.web.coupon.adapter.in.response.GifticonInfoResponseDto(c.id, c.couponInfo.imageUrl, c.couponInfo.barcode, c.couponInfo.name, c.couponInfo.expireDate, c.couponInfo.storeName, c.couponInfo.sentMemberName, c.couponInfo.memo, c.couponInfo.isMoneyCoupon, c.couponInfo.leftMoney)
     from Coupon c
     where c.member.id = :memberId
     and c.id = :id


### PR DESCRIPTION
## 개요
기프티콘 상세 조회 response dto에 sentMemberName 추가

## 작업 내용
재활용 티콘의 경우 기프티콘 상세조회에서 sentMemberName 필드가 존재해야합니다.
따라서 급하게 해당 필드를 추가하였습니다.
- 그냥 기프티콘의 경우 -> sentMemberName = null
- 재활용티콘을 등록한경우 -> sentMemberName = "example sent member name"

## 메모
