### PR TITLE
[Issue #83] 만든쿠폰 생성 시 id 반환

### DIFF
--- a/src/main/java/yapp/buddycon/common/response/DefaultIdResponseDto.java
+++ b/src/main/java/yapp/buddycon/common/response/DefaultIdResponseDto.java
@@ -1,0 +1,9 @@
+package yapp.buddycon.common.response;
+
+public record DefaultIdResponseDto (
+  Long id,
+  boolean success,
+  String message
+) {
+
+}

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/in/SharedCouponController.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/in/SharedCouponController.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import yapp.buddycon.common.response.DefaultIdResponseDto;
 import yapp.buddycon.common.response.DefaultResponseDto;
 import yapp.buddycon.web.auth.adapter.out.AuthMember;
 import yapp.buddycon.web.coupon.adapter.in.request.SharedCouponForCustomCouponCreationRequestDto;
@@ -42,14 +43,14 @@ public class SharedCouponController {
 
   @PostMapping(value = "/gifticon", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
   @Operation(summary = "기프티콘으로 만든 쿠폰 추가 (재활용)")
-  public DefaultResponseDto makeSharedCouponForGifticon(@RequestBody SharedCouponForGifticonCreationRequestDto dto,
+  public DefaultIdResponseDto makeSharedCouponForGifticon(@RequestBody SharedCouponForGifticonCreationRequestDto dto,
       @RequestPart MultipartFile image, AuthMember authMember) {
     return sharedCouponUseCase.makeSharedCouponForGifticon(dto, image, authMember.id());
   }
 
   @PostMapping(value = "/custom-coupon", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
   @Operation(summary = "제작티콘으로 만든 쿠폰 추가")
-  public DefaultResponseDto makeSharedCouponForCustomCoupon(@RequestBody SharedCouponForCustomCouponCreationRequestDto dto,
+  public DefaultIdResponseDto makeSharedCouponForCustomCoupon(@RequestBody SharedCouponForCustomCouponCreationRequestDto dto,
       @RequestPart MultipartFile image, AuthMember authMember) {
     return sharedCouponUseCase.makeSharedCouponForCustomCoupon(dto, image, authMember.id());
   }

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/out/SharedCouponCommandRepository.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/out/SharedCouponCommandRepository.java
@@ -3,6 +3,7 @@ package yapp.buddycon.web.coupon.adapter.out;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import yapp.buddycon.web.coupon.application.port.out.SharedCouponCommandPort;
+import yapp.buddycon.web.coupon.domain.SharedCoupon;
 
 @Repository
 @RequiredArgsConstructor
@@ -10,4 +11,8 @@ public class SharedCouponCommandRepository implements SharedCouponCommandPort {
 
   private final SharedCouponJpaRepository sharedCouponJpaRepository;
 
+  @Override
+  public void save(SharedCoupon sharedCoupon) {
+    sharedCouponJpaRepository.save(sharedCoupon);
+  }
 }

--- a/src/main/java/yapp/buddycon/web/coupon/application/port/in/SharedCouponUseCase.java
+++ b/src/main/java/yapp/buddycon/web/coupon/application/port/in/SharedCouponUseCase.java
@@ -2,6 +2,7 @@ package yapp.buddycon.web.coupon.application.port.in;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.multipart.MultipartFile;
+import yapp.buddycon.common.response.DefaultIdResponseDto;
 import yapp.buddycon.common.response.DefaultResponseDto;
 import yapp.buddycon.web.coupon.adapter.in.request.SharedCouponForCustomCouponCreationRequestDto;
 import yapp.buddycon.web.coupon.adapter.in.request.SharedCouponForGifticonCreationRequestDto;
@@ -16,8 +17,8 @@ public interface SharedCouponUseCase {
 
   DefaultResponseDto deleteSharedCoupon(Long memberId, Long couponId);
 
-  DefaultResponseDto makeSharedCouponForGifticon(SharedCouponForGifticonCreationRequestDto dto, MultipartFile image, Long memberId);
+  DefaultIdResponseDto makeSharedCouponForGifticon(SharedCouponForGifticonCreationRequestDto dto, MultipartFile image, Long memberId);
 
-  DefaultResponseDto makeSharedCouponForCustomCoupon(SharedCouponForCustomCouponCreationRequestDto dto, MultipartFile image, Long memberId);
+  DefaultIdResponseDto makeSharedCouponForCustomCoupon(SharedCouponForCustomCouponCreationRequestDto dto, MultipartFile image, Long memberId);
 
 }

--- a/src/main/java/yapp/buddycon/web/coupon/application/port/out/SharedCouponCommandPort.java
+++ b/src/main/java/yapp/buddycon/web/coupon/application/port/out/SharedCouponCommandPort.java
@@ -1,5 +1,9 @@
 package yapp.buddycon.web.coupon.application.port.out;
 
+import yapp.buddycon.web.coupon.domain.SharedCoupon;
+
 public interface SharedCouponCommandPort {
+
+  void save(SharedCoupon sharedCoupon);
 
 }

--- a/src/main/java/yapp/buddycon/web/coupon/application/service/SharedCouponService.java
+++ b/src/main/java/yapp/buddycon/web/coupon/application/service/SharedCouponService.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import yapp.buddycon.common.response.DefaultIdResponseDto;
 import yapp.buddycon.common.response.DefaultResponseDto;
 import yapp.buddycon.web.coupon.adapter.in.request.SharedCouponForCustomCouponCreationRequestDto;
 import yapp.buddycon.web.coupon.adapter.in.request.SharedCouponForGifticonCreationRequestDto;
@@ -59,24 +60,28 @@ public class SharedCouponService implements SharedCouponUseCase {
 
   @Override
   @Transactional
-  public DefaultResponseDto makeSharedCouponForGifticon(SharedCouponForGifticonCreationRequestDto dto, MultipartFile image, Long memberId) {
+  public DefaultIdResponseDto makeSharedCouponForGifticon(SharedCouponForGifticonCreationRequestDto dto, MultipartFile image, Long memberId) {
     Member sentMember = couponToMemberQueryPort.findById(memberId);
     String imageUrl = couponToAwsS3FileProviderPort.upload(image);
 
     Coupon coupon = couponQueryPort.findById(dto.couponId());
 
-    SharedCoupon.createForGifticon(dto, sentMember, imageUrl, coupon);
-    return new DefaultResponseDto(true, "만든 쿠폰(재활용)이 생성되었습니다.");
+    SharedCoupon sharedCoupon = SharedCoupon.createForGifticon(dto, sentMember, imageUrl, coupon);
+    sharedCouponCommandPort.save(sharedCoupon);
+
+    return new DefaultIdResponseDto(sharedCoupon.getId(), true, "만든 쿠폰(재활용)이 생성되었습니다.");
   }
 
   @Override
   @Transactional
-  public DefaultResponseDto makeSharedCouponForCustomCoupon(SharedCouponForCustomCouponCreationRequestDto dto, MultipartFile image, Long memberId) {
+  public DefaultIdResponseDto makeSharedCouponForCustomCoupon(SharedCouponForCustomCouponCreationRequestDto dto, MultipartFile image, Long memberId) {
     Member sentMember = couponToMemberQueryPort.findById(memberId);
     String imageUrl = couponToAwsS3FileProviderPort.upload(image);
 
-    SharedCoupon.createForCustomCoupon(dto, sentMember, imageUrl);
-    return new DefaultResponseDto(true, "만든 쿠폰(제작)이 생성되었습니다.");
+    SharedCoupon sharedCoupon = SharedCoupon.createForCustomCoupon(dto, sentMember, imageUrl);
+    sharedCouponCommandPort.save(sharedCoupon);
+
+    return new DefaultIdResponseDto(sharedCoupon.getId(), true, "만든 쿠폰(제작)이 생성되었습니다.");
   }
 
 }


### PR DESCRIPTION
## 개요

만든쿠폰 생성 시 id 반환

## 작업 내용

- 관련 API
  - POST::api/v1/coupon/share/gifticon
  - POST::api/v1/coupon/share/custom-coupon
- DefaultIdResponseDto 추가

## 메모

close #83 
