### PR TITLE
[Issue #85] 바코드로 sharedcoupon 조회 시 예외 코드 구체화

### DIFF
--- a/src/main/java/yapp/buddycon/common/exception/ErrorCode.java
+++ b/src/main/java/yapp/buddycon/common/exception/ErrorCode.java
@@ -46,6 +46,7 @@ public enum ErrorCode {
   CANT_ACCESS_COUPON(FORBIDDEN, "해당 쿠폰에 대한 권한이 없습니다."),
 
   NOT_EXIST_BARCODE_NUMBER(NO_CONTENT, "바코드에 해당하는 쿠폰이 존재하지 않습니다"),
+  ALREADY_SAVED_SHARED_COUPON(NO_CONTENT, "이미 저장된 만든 쿠폰입니다.")
 
   ;
 

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/in/response/SharedCustomCouponResponseDto.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/in/response/SharedCustomCouponResponseDto.java
@@ -1,6 +1,7 @@
 package yapp.buddycon.web.coupon.adapter.in.response;
 
 import java.time.LocalDate;
+import yapp.buddycon.web.coupon.domain.SharedCoupon;
 
 public record SharedCustomCouponResponseDto(
   Long id,
@@ -12,4 +13,18 @@ public record SharedCustomCouponResponseDto(
   String sentMemberName,
   String memo
 ) {
+
+  public static SharedCustomCouponResponseDto valueOf(SharedCoupon sharedCoupon) {
+    return new SharedCustomCouponResponseDto(
+        sharedCoupon.getId(),
+        sharedCoupon.getSharedCouponInfo().getImageUrl(),
+        sharedCoupon.getSharedCouponInfo().getBarcode(),
+        sharedCoupon.getSharedCouponInfo().getName(),
+        sharedCoupon.getSharedCouponInfo().getExpireDate(),
+        sharedCoupon.getSharedCouponInfo().getStoreName(),
+        sharedCoupon.getSharedCouponInfo().getSentMember().getName(),
+        sharedCoupon.getSharedCouponInfo().getMemo()
+    );
+  }
+
 }

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/in/response/SharedGifticonInfoResponseDto.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/in/response/SharedGifticonInfoResponseDto.java
@@ -1,6 +1,7 @@
 package yapp.buddycon.web.coupon.adapter.in.response;
 
 import java.time.LocalDate;
+import yapp.buddycon.web.coupon.domain.SharedCoupon;
 
 public record SharedGifticonInfoResponseDto(
   Long id,
@@ -11,4 +12,17 @@ public record SharedGifticonInfoResponseDto(
   String storeName,
   String memo
 ) {
+
+  public static SharedGifticonInfoResponseDto valueOf(SharedCoupon sharedCoupon) {
+    return new SharedGifticonInfoResponseDto(
+        sharedCoupon.getId(),
+        sharedCoupon.getSharedCouponInfo().getImageUrl(),
+        sharedCoupon.getSharedCouponInfo().getBarcode(),
+        sharedCoupon.getSharedCouponInfo().getName(),
+        sharedCoupon.getSharedCouponInfo().getExpireDate(),
+        sharedCoupon.getSharedCouponInfo().getStoreName(),
+        sharedCoupon.getSharedCouponInfo().getMemo()
+    );
+  }
+
 }

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/out/SharedCouponJpaRepository.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/out/SharedCouponJpaRepository.java
@@ -4,8 +4,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import yapp.buddycon.web.coupon.adapter.in.response.SharedCouponsResponseDto;
-import yapp.buddycon.web.coupon.adapter.in.response.SharedCustomCouponResponseDto;
-import yapp.buddycon.web.coupon.adapter.in.response.SharedGifticonInfoResponseDto;
 import yapp.buddycon.web.coupon.domain.SharedCoupon;
 
 import java.util.List;
@@ -13,26 +11,24 @@ import java.util.Optional;
 
 public interface SharedCouponJpaRepository extends JpaRepository<SharedCoupon, Long> {
   @Query(value = """
-    select new yapp.buddycon.web.coupon.adapter.in.response.SharedGifticonInfoResponseDto(s.id, s.sharedCouponInfo.imageUrl, s.sharedCouponInfo.barcode, s.sharedCouponInfo.name, s.sharedCouponInfo.expireDate, s.sharedCouponInfo.storeName, s.sharedCouponInfo.memo)
+    select s
     from SharedCoupon s
     where s.sharedCouponInfo.barcode = :barcode
     and s.coupon.couponType = 'REAL'
     and s.shared = true
-    and s.saved = false
     and s.deleted = false
   """)
-  Optional<SharedGifticonInfoResponseDto> findSharedGifticonByBarcode(String barcode);
+  Optional<SharedCoupon> findSharedGifticonByBarcode(String barcode);
 
   @Query(value = """
-    select new yapp.buddycon.web.coupon.adapter.in.response.SharedCustomCouponResponseDto(s.id, s.sharedCouponInfo.imageUrl, s.sharedCouponInfo.barcode, s.sharedCouponInfo.name, s.sharedCouponInfo.expireDate, s.sharedCouponInfo.storeName, s.sharedCouponInfo.sentMember.name, s.sharedCouponInfo.memo)
+    select s
     from SharedCoupon s
     where s.sharedCouponInfo.barcode = :barcode
     and s.coupon.couponType = 'CUSTOM'
     and s.shared = true
-    and s.saved = false
     and s.deleted = false
   """)
-  Optional<SharedCustomCouponResponseDto> findSharedCustomCouponByBarcode(String barcode);
+  Optional<SharedCoupon> findSharedCustomCouponByBarcode(String barcode);
 
 
   @Query(value = """

--- a/src/main/java/yapp/buddycon/web/coupon/adapter/out/SharedCouponQueryRepository.java
+++ b/src/main/java/yapp/buddycon/web/coupon/adapter/out/SharedCouponQueryRepository.java
@@ -6,8 +6,6 @@ import org.springframework.stereotype.Repository;
 import yapp.buddycon.common.exception.CustomException;
 import yapp.buddycon.common.exception.ErrorCode;
 import yapp.buddycon.web.coupon.adapter.in.response.SharedCouponsResponseDto;
-import yapp.buddycon.web.coupon.adapter.in.response.SharedCustomCouponResponseDto;
-import yapp.buddycon.web.coupon.adapter.in.response.SharedGifticonInfoResponseDto;
 import yapp.buddycon.web.coupon.application.port.out.CouponToSharedCouponQueryPort;
 import yapp.buddycon.web.coupon.application.port.out.SharedCouponQueryPort;
 import yapp.buddycon.web.coupon.domain.SharedCoupon;
@@ -21,12 +19,12 @@ public class SharedCouponQueryRepository implements SharedCouponQueryPort, Coupo
   private final SharedCouponJpaRepository sharedCouponJpaRepository;
 
   @Override
-  public SharedGifticonInfoResponseDto findSharedGifticonByBarcode(String barcode) {
+  public SharedCoupon findSharedGifticonByBarcode(String barcode) {
     return sharedCouponJpaRepository.findSharedGifticonByBarcode(barcode).orElseThrow(() -> new CustomException(ErrorCode.NOT_EXIST_BARCODE_NUMBER));
   }
 
   @Override
-  public SharedCustomCouponResponseDto findSharedCustomCouponByBarcode(String barcode) {
+  public SharedCoupon findSharedCustomCouponByBarcode(String barcode) {
     return sharedCouponJpaRepository.findSharedCustomCouponByBarcode(barcode).orElseThrow(() -> new CustomException(ErrorCode.NOT_EXIST_BARCODE_NUMBER));
   }
 

--- a/src/main/java/yapp/buddycon/web/coupon/application/port/out/CouponToSharedCouponQueryPort.java
+++ b/src/main/java/yapp/buddycon/web/coupon/application/port/out/CouponToSharedCouponQueryPort.java
@@ -1,13 +1,11 @@
 package yapp.buddycon.web.coupon.application.port.out;
 
-import yapp.buddycon.web.coupon.adapter.in.response.SharedCustomCouponResponseDto;
-import yapp.buddycon.web.coupon.adapter.in.response.SharedGifticonInfoResponseDto;
 import yapp.buddycon.web.coupon.domain.SharedCoupon;
 
 public interface CouponToSharedCouponQueryPort {
 
-  SharedGifticonInfoResponseDto findSharedGifticonByBarcode(String barcode);
-  SharedCustomCouponResponseDto findSharedCustomCouponByBarcode(String barcode);
+  SharedCoupon findSharedGifticonByBarcode(String barcode);
+  SharedCoupon findSharedCustomCouponByBarcode(String barcode);
 
   SharedCoupon findById(long id);
 }

--- a/src/main/java/yapp/buddycon/web/coupon/application/service/CouponService.java
+++ b/src/main/java/yapp/buddycon/web/coupon/application/service/CouponService.java
@@ -7,6 +7,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import yapp.buddycon.common.exception.CustomException;
+import yapp.buddycon.common.exception.ErrorCode;
 import yapp.buddycon.common.response.DefaultResponseDto;
 import yapp.buddycon.web.auth.adapter.out.AuthMember;
 import yapp.buddycon.web.coupon.adapter.in.request.CustomCouponCreationRequestDto;
@@ -30,6 +32,7 @@ import java.util.List;
 import yapp.buddycon.web.coupon.domain.CouponInfo;
 import yapp.buddycon.web.coupon.domain.CouponState;
 import yapp.buddycon.web.coupon.domain.CouponType;
+import yapp.buddycon.web.coupon.domain.SharedCoupon;
 
 @Service
 @RequiredArgsConstructor
@@ -114,12 +117,20 @@ public class CouponService implements CouponUseCase {
 
   @Override
   public SharedGifticonInfoResponseDto getSharedGifticonInfoFromBarcode(String barcode) {
-    return couponToSharedCouponQueryPort.findSharedGifticonByBarcode(barcode);
+    SharedCoupon sharedCoupon = couponToSharedCouponQueryPort.findSharedGifticonByBarcode(barcode);
+    if (sharedCoupon.isSaved()) {
+      throw new CustomException(ErrorCode.ALREADY_SAVED_SHARED_COUPON);
+    }
+    return SharedGifticonInfoResponseDto.valueOf(sharedCoupon);
   }
 
   @Override
   public SharedCustomCouponResponseDto getSharedCustomCouponInfoFromBarcode(String barcode) {
-    return couponToSharedCouponQueryPort.findSharedCustomCouponByBarcode(barcode);
+    SharedCoupon sharedCoupon = couponToSharedCouponQueryPort.findSharedCustomCouponByBarcode(barcode);
+    if (sharedCoupon.isSaved()) {
+      throw new CustomException(ErrorCode.ALREADY_SAVED_SHARED_COUPON);
+    }
+    return SharedCustomCouponResponseDto.valueOf(sharedCoupon);
   }
 
   @Override

--- a/src/main/java/yapp/buddycon/web/coupon/domain/SharedCoupon.java
+++ b/src/main/java/yapp/buddycon/web/coupon/domain/SharedCoupon.java
@@ -2,6 +2,7 @@ package yapp.buddycon.web.coupon.domain;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import yapp.buddycon.common.domain.BaseEntity;
 
@@ -12,6 +13,7 @@ import yapp.buddycon.web.member.domain.Member;
 
 @Entity
 @Builder
+@Getter
 @AllArgsConstructor
 @NoArgsConstructor
 public class SharedCoupon extends BaseEntity {


### PR DESCRIPTION
## 개요

바코드로 공유된 쿠폰 조회 시 발생할 수 있는 Exception을 나누어 좀 더 구체적으로 반환할 수 있도록 함.

## 작업 내용

- ErrorCode 추가
- 바코드로 조회하는 비즈니스 로직 수정

## 메모

close #85 
